### PR TITLE
Fix: gitignore pyc and staticfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 */__pycache__/**
 .idea/
 *pyc
-*gz
 staticfiles

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 */__pycache__/**
 .idea/
+*pyc
+*gz
+staticfiles


### PR DESCRIPTION
Before running the unit test, it is necessary to run python manage.py collectstatic, so this fix avoids adding static files and pyc