### PR TITLE
Agregar edición de fechas de reserva con validación de disponibilidad

### DIFF
--- a/pms/forms.py
+++ b/pms/forms.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from django import forms
-from django.forms import ModelForm
+from django.forms import ModelForm, DateInput
 
 from .models import Booking, Customer
 
@@ -55,4 +55,18 @@ class BookingFormExcluded(ModelForm):
             'guests': forms.HiddenInput(),
             'total': forms.HiddenInput(),
             'state': forms.HiddenInput(),
+        }
+
+
+class BookingDatesForm(ModelForm):
+    class Meta:
+        model = Booking
+        fields = ['checkin', 'checkout']
+        labels = {
+            'checkin': 'Fecha de entrada',
+            'checkout': 'Fecha de salida',
+        }
+        widgets = {
+            'checkin': DateInput(attrs={'type': 'date'}),
+            'checkout': DateInput(attrs={'type': 'date'}),
         }

--- a/pms/templates/edit_booking_dates.html
+++ b/pms/templates/edit_booking_dates.html
@@ -1,0 +1,22 @@
+{% extends "main.html" %}
+
+{% block content %}
+  <h1>Editar fechas de reserva {{ booking.code }}</h1>
+
+  <form method="post">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div class="mb-3">
+      {{ form.checkin.label_tag }}
+      {{ form.checkin }}
+      {{ form.errors.checkin }}
+    </div>
+    <div class="mb-3">
+      {{ form.checkout.label_tag }}
+      {{ form.checkout }}
+      {{ form.errors.checkout }}
+    </div>
+    <button class="btn btn-primary" type="submit">Guardar</button>
+    <a href="{% url 'home' %}" class="btn btn-secondary">Cancelar</a>
+  </form>
+{% endblock %}

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -1,3 +1,109 @@
-from django.test import TestCase
+# en pms/tests.py
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from .models import Room_type, Room, Booking
 
-# Create your tests here.
+@override_settings(
+    STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage'
+)
+class RoomFilterTests(TestCase):
+    def setUp(self):
+        rt = Room_type.objects.create(name="Single", price=20, max_guests=1)
+        Room.objects.create(name="Room 1.1", room_type=rt, description="")
+        Room.objects.create(name="Deluxe Room 1.2", room_type=rt, description="")
+        Room.objects.create(name="Room 2.1", room_type=rt, description="")
+
+    def test_filter_rooms_by_name(self):
+        url = reverse("rooms")
+        response = self.client.get(url, {"filter": "Room 1"})
+        self.assertEqual(response.status_code, 200)
+        names = [r["name"] for r in response.context["rooms"]]
+        self.assertIn("Room 1.1", names)
+        self.assertIn("Deluxe Room 1.2", names)
+        self.assertNotIn("Room 2.1", names)
+
+@override_settings(
+    STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage'
+)
+class DashboardOccupancyTests(TestCase):
+
+    def setUp(self):
+        # Creo 4 habitaciones
+        rt = Room_type.objects.create(name="Test", price=10, max_guests=2)
+        for i in range(4):
+            Room.objects.create(name=f"Room {i+1}", room_type=rt, description="")
+
+        # Creo 3 reservas en estado NEW
+        rooms = list(Room.objects.all())
+        for room in rooms[:3]:
+            Booking.objects.create(
+                state=Booking.NEW,
+                checkin="2025-06-10",
+                checkout="2025-06-12",
+                room=room,
+                guests=1,
+                customer=None,
+                total=20,
+                code=f"CODE{i}"
+            )
+
+    def test_occupancy_percentage_context(self):
+        url = reverse("dashboard")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        pct = response.context["dashboard"]["occupancy_pct"]
+        # 3 reservas / 4 habitaciones = 75.0%
+        self.assertEqual(pct, 75.0)
+        
+        
+@override_settings(
+    STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage'
+)
+class EditBookingDatesTests(TestCase):
+    def setUp(self):
+        rt = Room_type.objects.create(name="T", price=10, max_guests=2)
+        room = Room.objects.create(name="R1", room_type=rt, description="")
+        # Reserva original
+        self.booking = Booking.objects.create(
+            state=Booking.NEW,
+            checkin="2025-06-10",
+            checkout="2025-06-12",
+            room=room,
+            guests=1,
+            customer=None,
+            total=20,
+            code="ABC123"
+        )
+        # Otra reserva que provoca conflicto si solapan
+        Booking.objects.create(
+            state=Booking.NEW,
+            checkin="2025-06-15",
+            checkout="2025-06-17",
+            room=room,
+            guests=1,
+            customer=None,
+            total=20,
+            code="DEF456"
+        )
+
+    def test_successful_date_change(self):
+        url = reverse("edit_booking_dates", args=[self.booking.pk])
+        data = {'checkin': "2025-06-18", 'checkout': "2025-06-20"}
+        response = self.client.post(url, data, follow=True)
+        self.assertRedirects(response, reverse("home"))
+        self.booking.refresh_from_db()
+        self.assertEqual(str(self.booking.checkin), "2025-06-18")
+        self.assertEqual(str(self.booking.checkout), "2025-06-20")
+
+    def test_conflict_date_change(self):
+        url = reverse("edit_booking_dates", args=[self.booking.pk])
+        # Estas fechas solapan con DEF456
+        bad = {'checkin': "2025-06-16", 'checkout': "2025-06-18"}
+        response = self.client.post(url, bad)
+        self.assertEqual(response.status_code, 200)
+        # Debe mostrar el error de no disponibilidad
+        self.assertContains(response, "No hay disponibilidad para las fechas seleccionadas")
+        # Y la reserva no debe haber cambiado
+        self.booking.refresh_from_db()
+        self.assertEqual(str(self.booking.checkin), "2025-06-10")

--- a/pms/urls.py
+++ b/pms/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path("booking/<str:pk>/delete", views.DeleteBookingView.as_view(), name="delete_booking"),
     path("rooms/", views.RoomsView.as_view(), name="rooms"),
     path("room/<str:pk>/", views.RoomDetailsView.as_view(), name="room_details"),
-    path("dashboard/", views.DashboardView.as_view(), name="dashboard")
+    path("dashboard/", views.DashboardView.as_view(), name="dashboard"),
+    path("booking/<str:pk>/edit-dates/", views.EditBookingDatesView.as_view(), name="edit_booking_dates"),
 ]


### PR DESCRIPTION
Este PR permite editar las fechas de una reserva existente:

Añade BookingDatesForm para los campos checkin y checkout.

Nueva vista EditBookingDatesView con validación de conflictos.

Link “Editar fechas” junto a “Editar datos de contacto” en el listado.

Plantilla edit_booking_dates.html.

Tests que cubren cambios exitosos y conflictos de fechas.