### PR TITLE
Add filter and pagination to room listing

### DIFF
--- a/pms/templates/pagination.html
+++ b/pms/templates/pagination.html
@@ -1,0 +1,27 @@
+<div class="my-4 fs-5 text-secondary fw-medium">
+    <div class="d-flex justify-content-center align-items-center gap-3 flex-wrap">
+
+        {% if page.has_previous %}
+        <a href="?page={{ page.previous_page_number }}" class="btn btn-outline-primary btn-sm">
+            &laquo; Anterior
+        </a>
+        {% endif %}
+
+        <div class="d-flex align-items-center gap-2">
+        <span>Página</span>
+        <span class="badge bg-primary text-white px-3 py-2 rounded-pill">
+            {{ page.number }}
+        </span>
+        <span>de</span>
+        <span class="fw-semibold">{{ page.paginator.num_pages }}</span>
+        </div>
+
+        {% if page.has_next %}
+        <a href="?page={{ page.next_page_number }}" class="btn btn-outline-primary btn-sm">
+            Siguiente &raquo;
+        </a>
+        {% endif %}
+
+    </div>
+</div>
+

--- a/pms/templates/rooms.html
+++ b/pms/templates/rooms.html
@@ -1,19 +1,54 @@
 {% extends "main.html"%}
 
 {% block content %}
-<h1>Habitaciones del hotel</h1>
-{% for room in rooms%}
-<div class="row card mt-3 mb-3 hover-card bg-tr-250">
-    <div class="col p-3">
-        <div class="">
-            {{room.name}} ({{room.room_type__name}})
-        </div>
-        <div>
-            <a href="{% url 'room_details' pk=room.id%}">Ver detalles</a>
-        </div>
-        
-    </div>
-    
+<div class="d-flex flex-wrap justify-content-between align-items-center mb-4 p-3 bg-light rounded shadow-sm">
+    <h1 class="h4 text-dark mb-0">Habitaciones del hotel</h1>
+    <form action="{% url 'rooms' %}" method="GET" class="d-flex w-auto">
+        <input
+            class="form-control me-2"
+            type="search"
+            required
+            name="filter-rooms"
+            placeholder="Nombre habitación"
+            aria-label="Search"
+        >
+        <button class="d-flex btn btn-primary" type="submit">
+            <i class="bi bi-search me-1"></i>
+            Buscar
+        </button>
+    </form>
 </div>
+
+<p class="fst-italic text-secondary">
+    Habitaciones encontradas:
+    <span class="fw-semibold text-dark">{{ rooms_counts }}</span>
+</p>
+
+{% for room in rooms%}
+<div class="card mb-4 shadow-sm border-1">
+    <div class="card-body">
+        <div class="d-flex align-items-start mb-2 gap-4">
+            <h5 class="card-title mb-0 text-primary">{{ room.name }}</h5>
+            <span class="badge bg-light text-dark border">{{ room.room_type__name }}</span>
+        </div>
+        <div class="border-1 border"></div>
+        <p class="mb-1 text-muted">
+            <i class="bi bi-currency-dollar"></i> {{ room.room_type__price }}
+        </p>
+        <p class="mb-3 text-muted">
+            <i class="bi bi-people-fill"></i> Máx. {{ room.room_type__max_guests }} huésped{{ room.room_type__max_guests|pluralize }}
+        </p>
+        <a href="{% url 'room_details' pk=room.id %}" class="btn btn-outline-primary btn-sm">
+            Ver detalles
+        </a>
+    </div>
+</div>
+
+
 {% endfor %}
+
+{% if rooms_counts > 10 %}
+    {% include "pagination.html" with page=rooms %}
+{% endif %}
+
 {% endblock content%}

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -1,3 +1,69 @@
 from django.test import TestCase
+from django.urls import reverse
+from .models import Room, Room_type
+from django.test import override_settings
 
-# Create your tests here.
+# Override static files storage to prevent errors during test rendering
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class RoomsViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Set up a room type and create multiple rooms for testing
+        cls.room_type = Room_type.objects.create(
+            name="Suite",
+            price=200,
+            max_guests=3
+        )
+        # Create 16 rooms: Room 0.0 to Room 3.3
+        for i in range(4):
+            for j in range(4):
+                Room.objects.create(name=f"Room {i}.{j}", room_type=cls.room_type)
+
+    def test_filter_successful_room_1(self):
+        """
+        Ensure the filtering by room name works correctly.
+        Expect 4 rooms containing 'Room 3' in the name.
+        """
+        filter_room_name = 'Room 3'
+        rooms = Room.objects.filter(name__icontains=filter_room_name)
+        self.assertEqual(len(rooms), 4)
+
+    def test_list_view_status_ok(self):
+        """
+        Ensure the room list view returns HTTP 200 and uses the correct template.
+        """
+        response = self.client.get(reverse("rooms"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "rooms.html")
+
+    def test_room_filtering(self):
+        """
+        Ensure only filtered rooms are returned when a name query is provided.
+        """
+        Room.objects.create(name="Penthouse", room_type=self.room_type)
+        response = self.client.get(reverse("rooms") + "?filter-rooms=penthouse")
+        self.assertContains(response, "Penthouse")
+        self.assertNotContains(response, "Room 0")
+
+    def test_room_pagination(self):
+        """
+        Ensure only the first 10 rooms are displayed per page.
+        """
+        response = self.client.get(reverse("rooms"))
+        self.assertEqual(len(response.context["rooms"]), 10)
+        self.assertContains(response, "Room 0")
+
+    def test_room_pagination_second_page(self):
+        """
+        Ensure the second page displays the remaining rooms.
+        """
+        response = self.client.get(reverse("rooms") + "?page=2")
+        self.assertEqual(response.status_code, 200)
+        self.assertGreaterEqual(len(response.context["rooms"]), 5)
+
+    def test_invalid_page_redirects_to_first(self):
+        """
+        Ensure an invalid page number redirects to the first page.
+        """
+        response = self.client.get(reverse("rooms") + "?page=999")
+        self.assertRedirects(response, "/rooms/?page=1")

--- a/pms/views.py
+++ b/pms/views.py
@@ -1,8 +1,9 @@
 from django.db.models import F, Q, Count, Sum
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
+from django.core.paginator import Paginator, EmptyPage
 
 from .form_dates import Ymd
 from .forms import *
@@ -237,10 +238,27 @@ class RoomDetailsView(View):
 
 
 class RoomsView(View):
+    NUM_ROOMS_FOR_PAGE = 10
+    
     def get(self, request):
         # renders a list of rooms
-        rooms = Room.objects.all().values("name", "room_type__name", "id")
+        query = request.GET.dict()
+        filter_rooms = query.get("filter-rooms", "")
+        
+        rooms = Room.objects.all()
+        
+        if filter_rooms:
+            rooms = rooms.filter(name__icontains=filter_rooms)
+
+        paginator = Paginator(rooms, self.NUM_ROOMS_FOR_PAGE)
+        page_number = request.GET.get('page', 1)
+        try:
+            rooms_page = paginator.page(page_number)
+        except EmptyPage:
+            return HttpResponseRedirect(f"{request.path}?page=1")
+        
         context = {
-            'rooms': rooms
+            'rooms': rooms_page,
+            'rooms_counts': rooms.count()
         }
         return render(request, "rooms.html", context)

--- a/pms/views.py
+++ b/pms/views.py
@@ -249,6 +249,8 @@ class RoomsView(View):
         
         if filter_rooms:
             rooms = rooms.filter(name__icontains=filter_rooms)
+            
+        rooms = rooms.order_by('name')
 
         paginator = Paginator(rooms, self.NUM_ROOMS_FOR_PAGE)
         page_number = request.GET.get('page', 1)


### PR DESCRIPTION
✏️ Description:
This PR implements room name filtering functionality and also adds pagination to the listing to improve usability.

Changes made:
- Added filter by name (filter-rooms) via GET.
- Added pagination with 10 rooms per page.
- Visual improvements with modern Bootstrap styles.
- Added EmptyPage handling with redirection to page 1.

To review:
-Try searching for rooms by name in the search bar.
-Navigate between pages of results.

TestCase:
The following tests were added under `RoomsViewTest`:
- `test_filter_successful_room_1`: Checks that room filtering by name returns the expected count.
-  `test_list_view_status_ok`: Verifies that the room list view returns HTTP 200 and renders the correct template.
- `test_room_filtering`: Ensures filtering returns only matching room names and excludes others.
- `test_room_pagination`: Confirms that only 10 rooms are displayed per page.
- `test_room_pagination_second_page`: Validates that the second page shows the remaining rooms.
- `test_invalid_page_redirects_to_first`: Ensures that invalid page numbers (e.g., `page=999`) redirect to the first page.

![Captura de pantalla 2025-07-02 181852](https://github.com/user-attachments/assets/a1ea56e8-2e0e-4d4b-8cf7-e63794fb9411)

