### PR TITLE
Tarea 1: Filtro por nombre en vista de habitaciones

### DIFF
--- a/pms/templates/rooms.html
+++ b/pms/templates/rooms.html
@@ -2,6 +2,10 @@
 
 {% block content %}
 <h1>Habitaciones del hotel</h1>
+<form method="get" class="mb-3">
+    <input type="text" name="q" placeholder="Buscar habitación..." value="{{ request.GET.q }}" />
+    <button type="submit">Buscar</button>
+</form>
 {% for room in rooms%}
 <div class="row card mt-3 mb-3 hover-card bg-tr-250">
     <div class="col p-3">

--- a/pms/views.py
+++ b/pms/views.py
@@ -238,9 +238,14 @@ class RoomDetailsView(View):
 
 class RoomsView(View):
     def get(self, request):
-        # renders a list of rooms
-        rooms = Room.objects.all().values("name", "room_type__name", "id")
+        query = request.GET.get("q")
+        rooms = Room.objects.all()
+        if query:
+            rooms = rooms.filter(name__icontains=query)
+
+        rooms = rooms.values("name", "room_type__name", "id")
         context = {
             'rooms': rooms
         }
         return render(request, "rooms.html", context)
+


### PR DESCRIPTION
### ✅ Descripción

Se implementó un filtro por nombre en la vista de habitaciones.  
Esto permite al usuario buscar habitaciones ingresando una parte del nombre (por ejemplo, "Room 1").

### 🔧 Cambios realizados

- Se modificó la vista `RoomsView` para aceptar un parámetro `q` desde `GET` y filtrar con `icontains`
- Se actualizó el template `rooms.html` para agregar el formulario de búsqueda

### 🧪 Cómo probar

1. Ir a `/rooms/`
2. Escribir "Room 1" en el campo de búsqueda
3. Se muestran solo las habitaciones que contienen "Room 1" en su nombre
