### PR TITLE
Feat 2 add occupancy percentage

### DIFF
--- a/pms/statics/css/style.css
+++ b/pms/statics/css/style.css
@@ -30,12 +30,95 @@ body{
 }
 .card-customization{
     width: 250px;
-    height: 200px;
+    height: auto;
 }
 .dashboard-value{
     display: flex;
     flex-direction: row;
     justify-content: center;
-    height: 100%;
+    height: 50px;
     align-items: center;
+}
+
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(80px, 1fr));
+    gap: 0.5rem;
+    margin: 0 auto;
+}
+
+.calendar-cell {
+    position: relative;
+    aspect-ratio: 1 / 1;
+    border: 1px solid #dee2e6;
+    border-radius: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    font-size: 1rem;
+    color: #212529;
+}
+
+.calendar-day {
+    position: absolute;
+    top: 0.25rem;
+    right: 0.5rem;
+    font-size: 0.75rem;
+    color: #6c757d;
+}
+
+.bg-empty {
+    background-color: #f1f1f1;
+    color: #adb5bd;
+}
+
+.bg-low {
+    background-color: #d4edda;
+    color: #155724;
+}
+
+.bg-medium {
+    background-color: #fff3cd;
+    color: #856404;
+}
+
+.bg-full {
+    background-color: #f8d7da;
+    color: #721c24;
+}
+
+.bg-current {
+    background-color: #1a3257;
+    color: #fff;
+    transform: scale(1.1);
+}
+
+.calendar-content {
+    z-index: 1;
+}
+
+@media screen and (max-width:1000px) {
+    .calendar-grid {
+        grid-template-columns: repeat(7, minmax(40px, 1fr));
+    }
+    .calendar-content {
+        font-size: 14px;
+        padding: 4px;
+    }
+}
+
+@media screen and (max-width:500px) {
+    .calendar-grid {
+        grid-template-columns: repeat(7, minmax(30px, 1fr));
+    }
+    .calendar-content {
+        font-size: 12px;
+        padding: 3px;
+        margin-top: 10px;
+    }
+    .calendar-day {
+        top: 0.1rem;
+        right: 0.1rem;
+    }
 }

--- a/pms/templates/dashboard.html
+++ b/pms/templates/dashboard.html
@@ -3,25 +3,70 @@
 {% block content %}
 <h1>Dashboard</h1>
 <div class="card">
-    <h5 class="card-header">Hoy</h5>
-    <div class="d-flex justify-content-evenly pt-5 pb-5">
-        <div class="card text-white p-3 card-customization" style="background-color: #1000ff;">
-            <h5 class="small">Reservas hechas</h5>
-            <h1 class="dashboard-value">{{dashboard.new_bookings}}</h1>
-        </div>
-        <div class="card text-white p-3 card-customization" style="background-color: #00ab74;">
-            <h5 class="small">Huéspedes ingresando</h5>
-            <h1 class="dashboard-value">{{dashboard.incoming_guests}}</h1>
-        </div>
-        <div class="card text-white p-3 card-customization" style="background-color: #eeb258;">
-            <h5 class="small">Huéspedes saliendo</h5>
-            <h1 class="dashboard-value">{{dashboard.outcoming_guests}}</h1>
+    <div class="row p-4">
+        <div class="col-md-4 text-center">
+            <div class="card d-inline-block">
+                <h5 class="card-header">Hoy</h5>
+                <div class="d-grid gap-3 p-3">
+                    <div class="card text-white p-3 card-customization" style="background-color: #1000ff;">
+                        <h5 class="small">Reservas hechas</h5>
+                        <h1 class="dashboard-value">{{dashboard.new_bookings}}</h1>
+                    </div>
+                    <div class="card text-white p-3 card-customization" style="background-color: #00ab74;">
+                        <h5 class="small">Huéspedes ingresando</h5>
+                        <h1 class="dashboard-value">{{dashboard.incoming_guests}}</h1>
+                    </div>
+                    <div class="card text-white p-3 card-customization" style="background-color: #eeb258;">
+                        <h5 class="small">Huéspedes saliendo</h5>
+                        <h1 class="dashboard-value">{{dashboard.outcoming_guests}}</h1>
+                    </div>
+                    
+                    <div class="card text-white p-3 card-customization" style="background-color: #ff7f7f;">
+                        <h5 class="small">Total facturado</h5>
+                        <h1 class="dashboard-value">€ {% if dashboard.invoiced.total_sum == None %}0.00{% endif %} {{dashboard.invoiced.total_sum|floatformat:2}}</h1>
+                    </div>
+                </div>
+            </div>
         </div>
 
-        <div class="card text-white p-3 card-customization" style="background-color: #ff7f7f;">
-            <h5 class="small">Total facturado</h5>
-            <h1 class="dashboard-value">€ {% if dashboard.invoiced.total__sum == None %}0.00{% endif %} {{dashboard.invoiced.total__sum|floatformat:2}}</h1>
+        <div class="col-md-8 text-center">
+            <div class="card w-100">
+                <h5 class="card-header">Porcentaje de ocupación en el mes</h5>
+                {% if dashboard.num_rooms > 0 %}
+                    <div class="calendar-grid p-2">
+                    {% for day in dashboard.calendar_occupation %}
+                        <div class="calendar-cell 
+                            {% if day.occupation == "" or day.occupation == 100 %}
+                                bg-empty
+                            {% elif day.occupation >= 95 %}
+                                bg-full
+                            {% elif day.occupation > 50 and day.occupation < 95 %}
+                                bg-medium
+                            {% elif day.day == dashboard.current_day %}
+                                bg-current
+                            {% else %}
+                                bg-low
+                            {% endif %}
+                        ">
+                        <div class="calendar-day">
+                            {% if day.day == dashboard.current_day %}
+                                Hoy  
+                            {% endif %}
+                            {{ day.day }}
+                        </div>
+
+                        {% if day.occupation != "" %}
+                            <div class="calendar-content">{{ day.occupation|floatformat:0 }}%</div>
+                        {% endif %}
+                        </div>
+                    {% endfor %}
+                {% else %}
+                        <p class="mt-2">No cuenta con ninguna habitacion registrada</p>
+                {% endif %}
+                </div>
+            </div>
         </div>
     </div>
+
 </div>
 {% endblock content%}

--- a/pms/templates/pagination.html
+++ b/pms/templates/pagination.html
@@ -1,0 +1,27 @@
+<div class="my-4 fs-5 text-secondary fw-medium">
+    <div class="d-flex justify-content-center align-items-center gap-3 flex-wrap">
+
+        {% if page.has_previous %}
+        <a href="?page={{ page.previous_page_number }}" class="btn btn-outline-primary btn-sm">
+            &laquo; Anterior
+        </a>
+        {% endif %}
+
+        <div class="d-flex align-items-center gap-2">
+        <span>Página</span>
+        <span class="badge bg-primary text-white px-3 py-2 rounded-pill">
+            {{ page.number }}
+        </span>
+        <span>de</span>
+        <span class="fw-semibold">{{ page.paginator.num_pages }}</span>
+        </div>
+
+        {% if page.has_next %}
+        <a href="?page={{ page.next_page_number }}" class="btn btn-outline-primary btn-sm">
+            Siguiente &raquo;
+        </a>
+        {% endif %}
+
+    </div>
+</div>
+

--- a/pms/templates/rooms.html
+++ b/pms/templates/rooms.html
@@ -1,19 +1,54 @@
 {% extends "main.html"%}
 
 {% block content %}
-<h1>Habitaciones del hotel</h1>
-{% for room in rooms%}
-<div class="row card mt-3 mb-3 hover-card bg-tr-250">
-    <div class="col p-3">
-        <div class="">
-            {{room.name}} ({{room.room_type__name}})
-        </div>
-        <div>
-            <a href="{% url 'room_details' pk=room.id%}">Ver detalles</a>
-        </div>
-        
-    </div>
-    
+<div class="d-flex flex-wrap justify-content-between align-items-center mb-4 p-3 bg-light rounded shadow-sm">
+    <h1 class="h4 text-dark mb-0">Habitaciones del hotel</h1>
+    <form action="{% url 'rooms' %}" method="GET" class="d-flex w-auto">
+        <input
+            class="form-control me-2"
+            type="search"
+            required
+            name="filter-rooms"
+            placeholder="Nombre habitación"
+            aria-label="Search"
+        >
+        <button class="d-flex btn btn-primary" type="submit">
+            <i class="bi bi-search me-1"></i>
+            Buscar
+        </button>
+    </form>
 </div>
+
+<p class="fst-italic text-secondary">
+    Habitaciones encontradas:
+    <span class="fw-semibold text-dark">{{ rooms_counts }}</span>
+</p>
+
+{% for room in rooms%}
+<div class="card mb-4 shadow-sm border-1">
+    <div class="card-body">
+        <div class="d-flex align-items-start mb-2 gap-4">
+            <h5 class="card-title mb-0 text-primary">{{ room.name }}</h5>
+            <span class="badge bg-light text-dark border">{{ room.room_type__name }}</span>
+        </div>
+        <div class="border-1 border"></div>
+        <p class="mb-1 text-muted">
+            <i class="bi bi-currency-dollar"></i> {{ room.room_type__price }}
+        </p>
+        <p class="mb-3 text-muted">
+            <i class="bi bi-people-fill"></i> Máx. {{ room.room_type__max_guests }} huésped{{ room.room_type__max_guests|pluralize }}
+        </p>
+        <a href="{% url 'room_details' pk=room.id %}" class="btn btn-outline-primary btn-sm">
+            Ver detalles
+        </a>
+    </div>
+</div>
+
+
 {% endfor %}
+
+{% if rooms_counts > 10 %}
+    {% include "pagination.html" with page=rooms %}
+{% endif %}
+
 {% endblock content%}

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -1,3 +1,69 @@
 from django.test import TestCase
+from django.urls import reverse
+from .models import Room, Room_type
+from django.test import override_settings
 
-# Create your tests here.
+# Override static files storage to prevent errors during test rendering
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class RoomsViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Set up a room type and create multiple rooms for testing
+        cls.room_type = Room_type.objects.create(
+            name="Suite",
+            price=200,
+            max_guests=3
+        )
+        # Create 16 rooms: Room 0.0 to Room 3.3
+        for i in range(4):
+            for j in range(4):
+                Room.objects.create(name=f"Room {i}.{j}", room_type=cls.room_type)
+
+    def test_filter_successful_room_1(self):
+        """
+        Ensure the filtering by room name works correctly.
+        Expect 4 rooms containing 'Room 3' in the name.
+        """
+        filter_room_name = 'Room 3'
+        rooms = Room.objects.filter(name__icontains=filter_room_name)
+        self.assertEqual(len(rooms), 4)
+
+    def test_list_view_status_ok(self):
+        """
+        Ensure the room list view returns HTTP 200 and uses the correct template.
+        """
+        response = self.client.get(reverse("rooms"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "rooms.html")
+
+    def test_room_filtering(self):
+        """
+        Ensure only filtered rooms are returned when a name query is provided.
+        """
+        Room.objects.create(name="Penthouse", room_type=self.room_type)
+        response = self.client.get(reverse("rooms") + "?filter-rooms=penthouse")
+        self.assertContains(response, "Penthouse")
+        self.assertNotContains(response, "Room 0")
+
+    def test_room_pagination(self):
+        """
+        Ensure only the first 10 rooms are displayed per page.
+        """
+        response = self.client.get(reverse("rooms"))
+        self.assertEqual(len(response.context["rooms"]), 10)
+        self.assertContains(response, "Room 0")
+
+    def test_room_pagination_second_page(self):
+        """
+        Ensure the second page displays the remaining rooms.
+        """
+        response = self.client.get(reverse("rooms") + "?page=2")
+        self.assertEqual(response.status_code, 200)
+        self.assertGreaterEqual(len(response.context["rooms"]), 5)
+
+    def test_invalid_page_redirects_to_first(self):
+        """
+        Ensure an invalid page number redirects to the first page.
+        """
+        response = self.client.get(reverse("rooms") + "?page=999")
+        self.assertRedirects(response, "/rooms/?page=1")

--- a/pms/views.py
+++ b/pms/views.py
@@ -1,8 +1,9 @@
 from django.db.models import F, Q, Count, Sum
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
+from django.core.paginator import Paginator, EmptyPage
 
 from .form_dates import Ymd
 from .forms import *
@@ -237,10 +238,27 @@ class RoomDetailsView(View):
 
 
 class RoomsView(View):
+    NUM_ROOMS_FOR_PAGE = 10
+    
     def get(self, request):
         # renders a list of rooms
-        rooms = Room.objects.all().values("name", "room_type__name", "id")
+        query = request.GET.dict()
+        filter_rooms = query.get("filter-rooms", "")
+        
+        rooms = Room.objects.all()
+        
+        if filter_rooms:
+            rooms = rooms.filter(name__icontains=filter_rooms)
+
+        paginator = Paginator(rooms, self.NUM_ROOMS_FOR_PAGE)
+        page_number = request.GET.get('page', 1)
+        try:
+            rooms_page = paginator.page(page_number)
+        except EmptyPage:
+            return HttpResponseRedirect(f"{request.path}?page=1")
+        
         context = {
-            'rooms': rooms
+            'rooms': rooms_page,
+            'rooms_counts': rooms.count()
         }
         return render(request, "rooms.html", context)

--- a/pms/views.py
+++ b/pms/views.py
@@ -178,6 +178,7 @@ class EditBookingView(View):
 class DashboardView(View):
     def get(self, request):
         from datetime import date, time, datetime
+        import calendar
         today = date.today()
 
         # get bookings created today
@@ -209,14 +210,57 @@ class DashboardView(View):
                     .exclude(state="DEL")
                     .aggregate(Sum('total'))
                     )
+        
+        # get the occupancy for each day of the month
+        num_rooms = Room.objects.count()
+        occupation_day_in_month = []
+        year = today.year
+        month = today.month
+        _, max_day = calendar.monthrange(year, month)
+        
+        # list day left in the month
+        days_left = [day for day in range(today.day, max_day + 1)]
+        
+        start_date = datetime(year, month, 1)
+        end_date = datetime(year, month, max_day)
+        
+        # list bookings in the current month
+        bookings_in_month = Booking.objects.filter(
+            checkin__lte=end_date,
+            checkout__gte=start_date,
+            state="NEW"
+        )
+        
+        # Occupation for day
+        occupation_map = {day: 0 for day in range(1, max_day + 1)}
+        
+        # Loop booking in the month and count the occupation
+        for booking in bookings_in_month:
+            for day in range(
+                max(booking.checkin.day, 1),
+                min(booking.checkout.day, max_day) + 1
+            ):
+                occupation_map[day] += 1
 
+        if num_rooms > 0:
+            # calculate the occupation percentage for each day
+            occupation_day_in_month = [
+                {
+                    'day': day,
+                    'occupation': (occupation_map[day] * 100) / num_rooms if day in days_left else ""
+                }
+                for day in range(1, max_day + 1)
+            ]
+        
         # preparing context data
         dashboard = {
             'new_bookings': new_bookings,
             'incoming_guests': incoming,
             'outcoming_guests': outcoming,
-            'invoiced': invoiced
-
+            'invoiced': invoiced,
+            'calendar_occupation': occupation_day_in_month,
+            'current_day': today.day,
+            'num_rooms': num_rooms,
         }
 
         context = {

--- a/pms/views.py
+++ b/pms/views.py
@@ -249,6 +249,8 @@ class RoomsView(View):
         
         if filter_rooms:
             rooms = rooms.filter(name__icontains=filter_rooms)
+            
+        rooms = rooms.order_by('name')
 
         paginator = Paginator(rooms, self.NUM_ROOMS_FOR_PAGE)
         page_number = request.GET.get('page', 1)


### PR DESCRIPTION
✏️ Description:
This pull request introduces a new widget that displays daily occupancy percentages for the current month using a calendar layout. The current day is visually distinguished from the rest, and occupancy levels are clearly indicated for each date.

🔧 Changes Made:
Three main components were updated:
- views.py: Generates a list of days for the current month and calculates the daily occupancy percentage.
- 
- dashboard.html: Renders a calendar grid showing occupancy percentages per day. Conditional logic highlights the current day and differentiates days based on occupancy level.
- 
- styles.css: Adds styles to visually represent different occupancy levels and to format the calendar layout.


✅ How to Review:
- Go to the dashboard page.

- Verify that each day of the current month displays the correct occupancy percentage.

- Make or update reservations and confirm that the percentages update accordingly.

![image](https://github.com/user-attachments/assets/c984e370-8bb6-4b3c-a6f9-09194775108b)

