### PR TITLE
feat(rooms): Add rooms filtering functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 */__pycache__/**
 .idea/
+.venv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "[jinja-html]": {
-        "editor.tabSize": 4
+        "editor.tabSize": 4,
+        "djlint.enableLinting": false,
+        "editor.defaultFormatter": "monosans.djlint",
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "[jinja-html]": {
+        "editor.tabSize": 4
+    }
+}

--- a/pms/templates/rooms.html
+++ b/pms/templates/rooms.html
@@ -1,19 +1,56 @@
-{% extends "main.html"%}
+{% extends "main.html" %}
 
 {% block content %}
-<h1>Habitaciones del hotel</h1>
-{% for room in rooms%}
-<div class="row card mt-3 mb-3 hover-card bg-tr-250">
-    <div class="col p-3">
-        <div class="">
-            {{room.name}} ({{room.room_type__name}})
-        </div>
-        <div>
-            <a href="{% url 'room_details' pk=room.id%}">Ver detalles</a>
-        </div>
-        
+    <h1>Habitaciones del hotel</h1>
+
+    {# Search form #}
+    <div class="card card-body mb-4">
+        <form action="{% url 'rooms' %}" method="GET" class="row g-3 align-items-center">
+            <div class="col-auto">
+                <label for="filter" class="col-form-label">Buscar por nombre:</label>
+            </div>
+            <div class="col-md-6">
+                <input
+                    type="text"
+                    class="form-control"
+                    id="filter"
+                    name="filter"
+                    placeholder="Ej: Room 1"
+                    value="{{ filter }}">
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-primary">Buscar</button>
+            </div>
+            {% if filter %}
+                <div class="col-auto">
+                    <a href="{% url 'rooms' %}" class="btn btn-outline-secondary">Limpiar filtro</a>
+                </div>
+            {% endif %}
+        </form>
+        {% if filter %}
+            <div class="mt-2">
+                <small class="text-muted">Filtrando por: <strong>{{ filter }}</strong></small>
+            </div>
+        {% endif %}
     </div>
-    
-</div>
-{% endfor %}
+
+    {# Rooms #}
+    {% if rooms|length == 0 %}
+        <div class="alert alert-warning">
+            No se encontraron habitaciones{% if filter %} que contengan "{{ filter }}"{% endif %}.
+        </div>
+    {% else %}
+        {% for room in rooms%}
+        <div class="row card mt-3 mb-3 hover-card bg-tr-250">
+            <div class="col p-3">
+                <div class="">
+                    {{room.name}} ({{room.room_type__name}})
+                </div>
+                <div>
+                    <a href="{% url 'room_details' pk=room.id%}">Ver detalles</a>
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    {% endif %}
 {% endblock content%}

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -1,3 +1,162 @@
-from django.test import TestCase
+from django.test import TestCase, Client, override_settings
+from django.urls import reverse
 
-# Create your tests here.
+from .models import Room, Room_type
+
+
+@override_settings(
+    STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage'
+)
+class RoomsViewTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.room_type_single = Room_type.objects.create(
+            name='Individual',
+            price=50.0,
+            max_guests=1,
+        )
+        cls.room_type_double = Room_type.objects.create(
+            name='Doble',
+            price=80.0,
+            max_guests=2,
+        )
+
+        cls.room_1_1 = Room.objects.create(
+            name='Room 1.1',
+            room_type=cls.room_type_single,
+            description='Lorem ipsum',
+        )
+        cls.room_1_2 = Room.objects.create(
+            name='Room 1.2',
+            room_type=cls.room_type_single,
+            description='Lorem ipsum',
+        )
+        cls.room_1_10 = Room.objects.create(
+            name='Room 1.10',
+            room_type=cls.room_type_double,
+            description='Lorem ipsum',
+        )
+        cls.room_2_1 = Room.objects.create(
+            name='Room 2.1',
+            room_type=cls.room_type_double,
+            description='Lorem ipsum',
+        )
+        cls.room_2_2 = Room.objects.create(
+            name='Room 2.2',
+            room_type=cls.room_type_double,
+            description='Lorem ipsum',
+        )
+        cls.rooms = [
+            cls.room_1_1,
+            cls.room_1_2,
+            cls.room_1_10,
+            cls.room_2_1,
+            cls.room_2_2,
+        ]
+
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse('rooms')
+
+    def test_get_returns_all_rooms_when_no_filter_is_applied(self):
+        # Arrange
+        expected_status = 200
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, expected_status)
+        self.assertTemplateUsed(response, 'rooms.html')
+
+        rooms = response.context['rooms']
+        self.assertEqual(len(rooms), len(self.rooms))
+
+        self.assertEqual(response.context['filter'], '')
+
+        fetched_room_names = [room['name'] for room in rooms]
+        actual_room_names = [room.name for room in self.rooms]
+        self.assertCountEqual(fetched_room_names, actual_room_names)
+
+    def test_get_returns_filtered_rooms_when_filter_is_applied(self):
+        # Arrange
+        filter_value = 'Room 1'
+        expected_status = 200
+        expected_rooms = len([room for room in self.rooms if filter_value in room.name])
+
+        # Act
+        response = self.client.get(self.url, {'filter': filter_value})
+
+        # Assert
+        self.assertEqual(response.status_code, expected_status)
+        self.assertEqual(response.context['filter'], filter_value)
+
+        rooms = response.context['rooms']
+        self.assertEqual(len(rooms), expected_rooms)
+
+        room_names = [room['name'] for room in rooms]
+        for room in self.rooms:
+            if filter_value in room.name:
+                self.assertIn(room.name, room_names)
+            else:
+                self.assertNotIn(room.name, room_names)
+
+    def test_get_returns_case_insensitive_results_when_filtering(self):
+        # Arrange
+        expected_status = 200
+        expected_rooms = len([room for room in self.rooms if 'Room 1' in room.name])
+
+        # Act
+        response_lower = self.client.get(self.url, {'filter': 'room 1'})
+        response_upper = self.client.get(self.url, {'filter': 'ROOM 1'})
+        response_mixed = self.client.get(self.url, {'filter': 'RoOm 1'})
+
+        # Assert
+        self.assertEqual(response_lower.status_code, expected_status)
+        self.assertEqual(response_upper.status_code, expected_status)
+        self.assertEqual(response_mixed.status_code, expected_status)
+
+        rooms_lower = response_lower.context['rooms']
+        rooms_upper = response_upper.context['rooms']
+        rooms_mixed = response_mixed.context['rooms']
+
+        self.assertEqual(len(rooms_lower), expected_rooms)
+        self.assertEqual(len(rooms_upper), expected_rooms)
+        self.assertEqual(len(rooms_mixed), expected_rooms)
+
+        names_lower = set(room['name'] for room in rooms_lower)
+        names_upper = set(room['name'] for room in rooms_upper)
+        names_mixed = set(room['name'] for room in rooms_mixed)
+
+        self.assertEqual(names_lower, names_upper)
+        self.assertEqual(names_lower, names_mixed)
+
+    def test_get_returns_no_results_when_filter_has_no_matches(self):
+        # Arrange
+        filter_value = 'Room 3.1'
+        expected_status = 200
+        expected_rooms = 0
+
+        # Act
+        response = self.client.get(self.url, {'filter': filter_value})
+
+        # Assert
+        self.assertEqual(response.status_code, expected_status)
+
+        rooms = response.context['rooms']
+        self.assertEqual(len(rooms), expected_rooms)
+
+        self.assertEqual(response.context['filter'], filter_value)
+
+    def test_get_returns_all_rooms_when_filter_is_empty(self):
+        # Arrange
+        expected_status = 200
+
+        # Act
+        response = self.client.get(self.url, {'filter': ''})
+
+        # Assert
+        self.assertEqual(response.status_code, expected_status)
+
+        rooms = response.context['rooms']
+        self.assertEqual(len(rooms), len(self.rooms))

--- a/pms/views.py
+++ b/pms/views.py
@@ -239,8 +239,18 @@ class RoomDetailsView(View):
 class RoomsView(View):
     def get(self, request):
         # renders a list of rooms
-        rooms = Room.objects.all().values("name", "room_type__name", "id")
+        query = request.GET.dict()
+        if 'filter' in query and query['filter']:
+            rooms = (
+                Room.objects
+                .filter(name__icontains=query['filter'])
+                .values('name', 'room_type__name', 'id')
+            )
+        else:
+            rooms = Room.objects.all().values('name', 'room_type__name', 'id')
+
         context = {
-            'rooms': rooms
+            'rooms': rooms,
+            'filter': query.get('filter', '')
         }
         return render(request, "rooms.html", context)


### PR DESCRIPTION
**Descripción:**
Actualmente, la página "Habitaciones" lista todas las habitaciones que existen en la base de datos. Se solicita añadir un formulario en la parte superior para poder filtrar los resultados de la lista, permitiendo buscar únicamente por el nombre de la habitación. Dicho filtro debe buscar habitaciones cuyo campo “name” contenga el texto introducido en el formulario. Por ejemplo, si se introduce “Room 1”, se mostrarán las habitaciones “Room 1.1”, “Room 1.2”, etc, pero no otras como “Room 2.1”. 

**Cambios realizados:**
- Se añadió el formulario de búsqueda entre el título de la página y la lista de habitaciones para filtrar las habitaciones por nombre sin tomar en cuenta mayúsculas y minúsculas.
- Se introdujo un mensaje en caso de que no se encuentren habitaciones con el filtro enviado.
- Se agregaron las pruebas unitarias correspondientes al método `get` de la vista `RoomsView` probando los dos escenarios principales (obtener todas las habitaciones y filtrar las habitaciones) y escenarios alternativos.
- Se corrige la indentación del template utilizando `djlint`, un formateador y linter de plantillas Jinja.
- Se agrega la carpeta `.venv` (entorno virtual) al `.gitignore`.

**Imágenes:**
- Formulario de búsqueda
<img width="1342" height="442" alt="image" src="https://github.com/user-attachments/assets/11c43df7-3e73-4e02-bb1c-6b8089313982" />
- Filtrando habitaciones
<img width="1344" height="724" alt="image" src="https://github.com/user-attachments/assets/eb7fcfe3-c3a1-4437-8777-9f482189a28f" />
- Mensaje indicando que no se encontraron habitaciones
<img width="1327" height="274" alt="image" src="https://github.com/user-attachments/assets/8d4c43dd-c4ad-439b-94cb-8e098689571d" />

**Demo:**
![Filtering rooms](https://github.com/user-attachments/assets/dd197779-de15-49e0-9748-82eb30fea4d9)

**Pruebas unitarias:**
Los nombres de los métodos siguen la siguiente convención de nombres mnemotécnicos:
`test_<nombre_del_método>_<resultado_esperado>_<causa_o_situacion>` separando el cuerpo en Arrange, Act y Assert. Así, los tests se documentan solos.

- Método `get` de la vista `RoomsView`:
    - `test_get_returns_all_rooms_when_no_filter_is_applied`: Debe devolver todos los registros de habitaciones cuando no se aplica ningún filtro.
    - `test_get_returns_filtered_rooms_when_filter_is_applied`: Debe devolver solo los registros de habitaciones que coinciden con el filtro aplicado.
    - `test_get_returns_case_insensitive_results_when_filtering`: Debe devolver resultados sin distinguir entre mayúsculas y minúsculas cuando se aplica un filtro.
    - `test_get_returns_no_results_when_filter_has_no_matches`: Debe devolver un mensaje de "No se encontraron habitaciones" cuando el filtro no coincide con ningún registro.
    - `test_get_returns_all_rooms_when_filter_is_empty`: Debe devolver todos los registros de habitaciones cuando el filtro está vacío.
<img width="447" height="187" alt="image" src="https://github.com/user-attachments/assets/abeadf36-f267-4715-ba30-707c58178b08" />
