### PR TITLE
feat(booking): Add logic to edit booking dates

### DIFF
--- a/pms/forms.py
+++ b/pms/forms.py
@@ -56,3 +56,23 @@ class BookingFormExcluded(ModelForm):
             'total': forms.HiddenInput(),
             'state': forms.HiddenInput(),
         }
+
+
+class EditBookingDatesForm(ModelForm):
+    class Meta:
+        model = Booking
+        fields = ['checkin', 'checkout']
+        labels = {
+            'checkin': 'Fecha de entrada',
+            'checkout': 'Fecha de salida'
+        }
+        widgets = {
+            'checkin': forms.DateInput(attrs={'type': 'date', 'min': datetime.today().strftime('%Y-%m-%d')}),
+            'checkout': forms.DateInput(
+                attrs={
+                    'type': 'date',
+                    'min': datetime.today().strftime('%Y-%m-%d'),
+                    'max': datetime.today().replace(month=12, day=31).strftime('%Y-%m-%d'),
+                },
+            ),
+        }

--- a/pms/templates/edit_booking_dates.html
+++ b/pms/templates/edit_booking_dates.html
@@ -1,0 +1,40 @@
+{% extends 'main.html' %}
+
+{% block content %}
+    <h1>Editar fechas de reserva</h1>
+
+    <div class="card card-body mb-3">
+        <h5>Reserva: {{ booking.code }}</h5>
+        <p>
+            <strong>Habitación:</strong> {{ booking.room.name }}
+        </p>
+        <p>
+            <strong>Cliente:</strong> {{ booking.customer.name }}
+        </p>
+        <p>
+            <strong>Fechas actuales:</strong> {{ booking.checkin }} - {{ booking.checkout }}
+        </p>
+    </div>
+
+    {% if error %}
+        <div class="alert alert-danger" role="alert">
+            <i class="bi bi-exclamation-triangle-fill"></i>
+            {{ error }}
+        </div>
+    {% endif %}
+
+    <form action="" method="post">
+        {% csrf_token %}
+        {% for field in form %}
+            <div class="row mb-3">
+                <div class="col-md-2">{{ field.label_tag }}</div>
+                <div class="col-md-4">{{ field }}</div>
+            </div>
+        {% endfor %}
+
+        <div class="mt-3">
+            <a class="btn btn-outline-primary" href="{% url 'home' %}">Volver</a>
+            <button class="btn btn-primary" type="submit">Guardar fechas</button>
+        </div>
+    </form>
+{% endblock content %}

--- a/pms/templates/home.html
+++ b/pms/templates/home.html
@@ -64,19 +64,18 @@
             </div>
             <div class="row">
                 <div class="col">
-
                     <a href="{% url 'edit_booking' pk=booking.id%} " >Editar datos de contacto</a>
                 </div>
                 <div class="col">
-
+                    {% if booking.state != "DEL" %}
+                    <a href="{% url 'edit_booking_dates' pk=booking.id%} " >Editar fechas</a>
+                    {% endif %}
                 </div>
                 <div class="col">
-
                     {% if booking.state != "DEL" %}
                     <a href="{% url 'delete_booking' pk=booking.id%} " >Cancelar reserva</a>
                     {% endif %}
                 </div>
-
             </div>
 
         </div>

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -1,3 +1,186 @@
-from django.test import TestCase
+from datetime import date, timedelta
 
-# Create your tests here.
+from django.test import TestCase, Client, override_settings
+from django.urls import reverse
+
+from .models import Room, Room_type, Booking, Customer
+
+
+@override_settings(
+    STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage'
+)
+class EditBookingDatesViewTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.room_type = Room_type.objects.create(name='Doble', price=80.0, max_guests=2)
+
+        cls.room_1 = Room.objects.create(
+            name='Room 1.1', room_type=cls.room_type, description='Double room'
+        )
+        cls.room_2 = Room.objects.create(
+            name='Room 2.1', room_type=cls.room_type, description='Double room'
+        )
+
+        cls.customer = Customer.objects.create(
+            name='Test Customer', email='test@example.com', phone='123456789'
+        )
+
+        today = date.today()
+        cls.booking_to_edit = Booking.objects.create(
+            state='NEW',
+            checkin=today,
+            checkout=today + timedelta(days=2),
+            room=cls.room_1,
+            guests=2,
+            customer=cls.customer,
+            total=160.0,
+            code='EDIT0001',
+        )
+
+        cls.conflicting_booking = Booking.objects.create(
+            state='NEW',
+            checkin=today + timedelta(days=5),
+            checkout=today + timedelta(days=7),
+            room=cls.room_1,
+            guests=2,
+            customer=cls.customer,
+            total=160.0,
+            code='CONF0001',
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse('edit_booking_dates', kwargs={'pk': self.booking_to_edit.id})
+
+    def test_view_loads_successfully_and_contains_form(self):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertTemplateUsed(response, 'edit_booking_dates.html')
+        self.assertIn('booking', response.context)
+        self.assertIn('form', response.context)
+
+    def test_post_updates_dates_when_room_is_available(self):
+        # Arrange
+        today = date.today()
+        new_checkin = today + timedelta(days=10)
+        new_checkout = today + timedelta(days=12)
+        post_data = {
+            'checkin': new_checkin.strftime('%Y-%m-%d'),
+            'checkout': new_checkout.strftime('%Y-%m-%d'),
+        }
+        expected_status_code = 302
+
+        # Act
+        response = self.client.post(self.url, post_data)
+
+        # Assert
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertEqual(response.url, '/')
+
+        self.booking_to_edit.refresh_from_db()
+        self.assertEqual(self.booking_to_edit.checkin, new_checkin)
+        self.assertEqual(self.booking_to_edit.checkout, new_checkout)
+
+    def test_post_shows_error_when_dates_conflict_with_another_booking(self):
+        # Arrange
+        today = date.today()
+        new_checkin = today + timedelta(days=5)
+        new_checkout = today + timedelta(days=6)
+        post_data = {
+            'checkin': new_checkin.strftime('%Y-%m-%d'),
+            'checkout': new_checkout.strftime('%Y-%m-%d'),
+        }
+        expected_error = 'No hay disponibilidad para las fechas seleccionadas'
+
+        # Act
+        response = self.client.post(self.url, post_data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'edit_booking_dates.html')
+        self.assertIn('error', response.context)
+        self.assertEqual(response.context['error'], expected_error)
+
+        self.booking_to_edit.refresh_from_db()
+        self.assertEqual(self.booking_to_edit.checkin, date.today())
+
+    def test_post_allows_keeping_same_dates_without_conflict(self):
+        # Arrange
+        today = date.today()
+        post_data = {
+            'checkin': today.strftime('%Y-%m-%d'),
+            'checkout': (today + timedelta(days=2)).strftime('%Y-%m-%d'),
+        }
+        expected_status_code = 302
+
+        # Act
+        response = self.client.post(self.url, post_data)
+
+        # Assert
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertEqual(response.url, '/')
+
+    def test_post_ignores_cancelled_bookings_when_checking_availability(self):
+        # Arrange
+        today = date.today()
+        new_checkin = today + timedelta(days=15)
+        new_checkout = today + timedelta(days=17)
+
+        Booking.objects.create(
+            state='DEL',
+            checkin=new_checkin,
+            checkout=new_checkout,
+            room=self.room_1,
+            guests=2,
+            customer=self.customer,
+            total=160.0,
+            code='CANC0001',
+        )
+
+        post_data = {
+            'checkin': new_checkin.strftime('%Y-%m-%d'),
+            'checkout': new_checkout.strftime('%Y-%m-%d'),
+        }
+        expected_status_code = 302
+
+        # Act
+        response = self.client.post(self.url, post_data)
+
+        # Assert
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertEqual(response.url, '/')
+
+    def test_post_allows_same_dates_in_different_room(self):
+        # Arrange
+        today = date.today()
+        new_checkin = today + timedelta(days=20)
+        new_checkout = today + timedelta(days=22)
+
+        Booking.objects.create(
+            state='NEW',
+            checkin=new_checkin,
+            checkout=new_checkout,
+            room=self.room_2,
+            guests=2,
+            customer=self.customer,
+            total=160.0,
+            code='ROOM2001',
+        )
+
+        post_data = {
+            'checkin': new_checkin.strftime('%Y-%m-%d'),
+            'checkout': new_checkout.strftime('%Y-%m-%d'),
+        }
+
+        # Act
+        response = self.client.post(self.url, post_data)
+
+        # Assert
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/')

--- a/pms/urls.py
+++ b/pms/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path("search/booking/", views.BookingSearchView.as_view(), name="booking_search"),
     path("booking/<str:pk>/", views.BookingView.as_view(), name="booking"),
     path("booking/<str:pk>/edit", views.EditBookingView.as_view(), name="edit_booking"),
+    path("booking/<str:pk>/edit-dates", views.EditBookingDatesView.as_view(), name="edit_booking_dates"),
     path("booking/<str:pk>/delete", views.DeleteBookingView.as_view(), name="delete_booking"),
     path("rooms/", views.RoomsView.as_view(), name="rooms"),
     path("room/<str:pk>/", views.RoomDetailsView.as_view(), name="room_details"),

--- a/pms/views.py
+++ b/pms/views.py
@@ -1,12 +1,20 @@
+from datetime import date
 from django.db.models import F, Q, Count, Sum
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render, redirect
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from .form_dates import Ymd
-from .forms import *
-from .models import Room
+from .forms import (
+    BookingForm,
+    BookingFormExcluded,
+    CustomerForm,
+    EditBookingDatesForm,
+    RoomSearchForm,
+)
+from .models import Booking, Room
 from .reservation_code import generate
 
 
@@ -172,6 +180,54 @@ class EditBookingView(View):
         if customer_form.is_valid():
             customer_form.save()
             return redirect("/")
+
+
+class EditBookingDatesView(View):
+    """View for editing booking dates."""
+
+    def get(self, request: HttpRequest, pk: int) -> HttpResponse:
+        booking = Booking.objects.get(id=pk)
+        form = EditBookingDatesForm(instance=booking)
+        context = {
+            'booking': booking,
+            'form': form,
+            'error': None
+        }
+        return render(request, 'edit_booking_dates.html', context)
+
+    @method_decorator(ensure_csrf_cookie)
+    def post(self, request: HttpRequest, pk: int) -> HttpResponse:
+        booking = Booking.objects.get(id=pk)
+        form = EditBookingDatesForm(request.POST, instance=booking)
+        if form.is_valid():
+            new_checkin = form.cleaned_data['checkin']
+            new_checkout = form.cleaned_data['checkout']
+            if self.__has_conflicting_bookings(booking, new_checkin, new_checkout):
+                context = {
+                    'booking': booking,
+                    'form': form,
+                    'error': 'No hay disponibilidad para las fechas seleccionadas'
+                }
+                return render(request, 'edit_booking_dates.html', context)
+
+            form.save()
+            return redirect('/')
+
+        context = {
+            'booking': booking,
+            'form': form,
+            'error': None
+        }
+        return render(request, 'edit_booking_dates.html', context)
+
+    def __has_conflicting_bookings(self, booking: Booking, new_checkin: date, new_checkout: date) -> bool:
+        conflicting_bookings = (
+            Booking.objects
+            .filter(room=booking.room, state='NEW')
+            .exclude(id=booking.id)
+            .filter(checkin__lte=new_checkout, checkout__gte=new_checkin)
+        )
+        return conflicting_bookings.exists()
 
 
 class DashboardView(View):


### PR DESCRIPTION
**Descripción:**
Actualmente, en la pantalla principal se muestran todas las reservas realizadas y se permite actualmente poder editar los datos de contacto. Se solicita añadir una nueva funcionalidad para editar las fechas de la reserva, añadiendo un enlace a cada reserva similar al de “Editar datos de contacto”. Dicho enlace debe llevar una nueva página con un formulario similar al de crear nueva reserva, pero solo con los campos de fecha de entrada y salida y un botón de “Guardar”.

Además de editar los campos de la reserva, se debe realizar la misma validación que al crear una nueva reserva, es decir, comprobar que la habitación actual está disponible en las nuevas fechas seleccionadas. Si existen otras reservas ocupando en las mismas fechas, se debe mostrar un error: “No hay disponibilidad para las fechas seleccionadas”.

**Cambios realizados:**
- Se añadió el formulario de edición para el Checkin y Checkout de la reserva.
- Se introdujo un mensaje en caso de que no haya disponibilidad para la habitación de la reserva durante las fechas seleccionadas.
- Se agregaron las pruebas unitarias correspondientes al método `get` y `post` de la vista `EditBookingDatesView`.
- Se agrega la opción "Editar fechas" en cada reserva confirmada en la vista principal.

**Imágenes:**
- Opción para editar las fechas
<img width="1328" height="469" alt="image" src="https://github.com/user-attachments/assets/8509b120-1069-4c7b-afda-5ea6497b2862" />
- Reservas con la misma habitación
<img width="1345" height="382" alt="image" src="https://github.com/user-attachments/assets/c7de59d1-3b3e-456b-be08-aec7ce0d3793" />
- Formulario de edición
<br>
<img width="613" height="426" alt="image" src="https://github.com/user-attachments/assets/5dee973b-a40f-42a9-a55b-6bd76a8c5766" />
<br>
- Mensaje indicando conflicto de fechas
<img width="734" height="487" alt="image" src="https://github.com/user-attachments/assets/d276f92f-dde8-46f8-a189-0f98a9805398" />
<br>
- Reserva actualizada
<img width="1331" height="390" alt="image" src="https://github.com/user-attachments/assets/f5b39954-0e79-4b33-a860-3b62342b1582" />

<br>

**Demo:**
![editing booking dates](https://github.com/user-attachments/assets/81bf8fb3-a154-40c3-9bc4-00814040ee79)

**Pruebas unitarias:**
Los nombres de los métodos siguen la siguiente convención de nombres mnemotécnicos:
`test_<nombre_del_método>_<resultado_esperado>_<causa_o_situacion>` separando el cuerpo en Arrange, Act y Assert. Así, los tests se documentan solos.

- Método `get` de la vista `EditBookingDatesView`:
    - `test_view_loads_successfully_and_contains_form`: Debe cargar la vista correctamente y contener el formulario de edición de fechas en el contexto.
- Método `post` de la vista `EditBookingDatesView`:
    - `test_post_updates_dates_when_room_is_available`: Debe actualizar las fechas de la reserva cuando la habitación está disponible para las nuevas fechas seleccionadas.
    - `test_post_shows_error_when_dates_conflict_with_another_booking`: Debe mostrar un mensaje de error cuando las nuevas fechas seleccionadas entran en conflicto con otra reserva confirmada de la misma habitación.
    - `test_post_allows_keeping_same_dates_without_conflict`: Debe permitir mantener las mismas fechas sin generar conflicto con la propia reserva.
    - `test_post_ignores_cancelled_bookings_when_checking_availability`: Debe ignorar las reservas canceladas al verificar la disponibilidad de la habitación para las nuevas fechas.
    - `test_post_allows_same_dates_in_different_room`: Debe permitir usar las mismas fechas cuando existe una reserva confirmada en una habitación diferente.
<img width="456" height="185" alt="image" src="https://github.com/user-attachments/assets/9d0094df-728e-48b6-b900-95ca27bbf5fb" />
