### PR TITLE
feat(dashboard): add occupancy rate widget and date range filter

### DIFF
--- a/pms/templates/dashboard.html
+++ b/pms/templates/dashboard.html
@@ -2,8 +2,19 @@
 
 {% block content %}
 <h1>Dashboard</h1>
+
+<form method="get" action="" class="mb-4">
+    <div class="input-group" style="max-width: 500px;">
+        <span class="input-group-text">Desde</span>
+        <input type="date" name="date_from" class="form-control" value="{{ date_from }}">
+        <span class="input-group-text">Hasta</span>
+        <input type="date" name="date_to" class="form-control" value="{{ date_to }}">
+        <button class="btn btn-outline-secondary" type="submit">Ver</button>
+    </div>
+</form>
+
 <div class="card">
-    <h5 class="card-header">Hoy</h5>
+    <h5 class="card-header">{{ date_from }} — {{ date_to }}</h5>
     <div class="d-flex justify-content-evenly pt-5 pb-5">
         <div class="card text-white p-3 card-customization" style="background-color: #1000ff;">
             <h5 class="small">Reservas hechas</h5>
@@ -20,7 +31,12 @@
 
         <div class="card text-white p-3 card-customization" style="background-color: #ff7f7f;">
             <h5 class="small">Total facturado</h5>
-            <h1 class="dashboard-value">€ {% if dashboard.invoiced.total__sum == None %}0.00{% endif %} {{dashboard.invoiced.total__sum|floatformat:2}}</h1>
+            <h1 class="dashboard-value">€ {{ dashboard.invoiced.total__sum|default:0|floatformat:2 }}</h1>
+        </div>
+
+        <div class="card text-white p-3 card-customization" style="background-color: #6f42c1;">
+            <h5 class="small">% Ocupación</h5>
+            <h1 class="dashboard-value">{{dashboard.occupancy_rate|floatformat:2}}%</h1>
         </div>
     </div>
 </div>

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -1,3 +1,135 @@
-from django.test import TestCase
+import datetime
 
-# Create your tests here.
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from .models import Booking, Customer, Room, Room_type
+
+SIMPLE_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def create_room_type(name="Individual", max_guests=1, price=20.0):
+    return Room_type.objects.create(name=name, max_guests=max_guests, price=price)
+
+
+def create_room(name, room_type):
+    return Room.objects.create(name=name, room_type=room_type, description="")
+
+
+def create_customer(name="John Doe", email="john@example.com", phone="123456789"):
+    return Customer.objects.create(name=name, email=email, phone=phone)
+
+
+def create_booking(room, customer, state=Booking.NEW, checkin=None, checkout=None):
+    checkin = checkin or datetime.date.today()
+    checkout = checkout or checkin + datetime.timedelta(days=1)
+    return Booking.objects.create(
+        room=room,
+        customer=customer,
+        state=state,
+        checkin=checkin,
+        checkout=checkout,
+        guests=1,
+        total=room.room_type.price,
+        code="ABC12345",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dashboard — Occupancy rate widget + date range selector
+# ---------------------------------------------------------------------------
+
+@override_settings(STATICFILES_STORAGE=SIMPLE_STORAGE)
+class DashboardOccupancyTest(TestCase):
+
+    def setUp(self):
+        self.rt = create_room_type()
+        self.room = create_room("Room 1.1", self.rt)
+        self.customer = create_customer()
+        self.today = datetime.date.today()
+        self.today_str = self.today.strftime('%Y-%m-%d')
+
+    def test_dashboard_defaults_to_today_for_both_dates(self):
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["date_from"], self.today_str)
+        self.assertEqual(response.context["date_to"], self.today_str)
+
+    def test_dashboard_accepts_date_range_from_query_string(self):
+        response = self.client.get(reverse("dashboard"), {
+            "date_from": "2024-01-01",
+            "date_to": "2024-01-31",
+        })
+        self.assertEqual(response.context["date_from"], "2024-01-01")
+        self.assertEqual(response.context["date_to"], "2024-01-31")
+
+    def test_invalid_dates_fall_back_to_today(self):
+        response = self.client.get(reverse("dashboard"), {
+            "date_from": "bad",
+            "date_to": "also-bad",
+        })
+        self.assertEqual(response.context["date_from"], self.today_str)
+        self.assertEqual(response.context["date_to"], self.today_str)
+
+    def test_inverted_range_is_corrected(self):
+        response = self.client.get(reverse("dashboard"), {
+            "date_from": "2024-01-31",
+            "date_to": "2024-01-01",
+        })
+        self.assertEqual(response.context["date_from"], "2024-01-01")
+        self.assertEqual(response.context["date_to"], "2024-01-31")
+
+    def test_occupancy_rate_is_zero_with_no_bookings(self):
+        response = self.client.get(reverse("dashboard"), {
+            "date_from": self.today_str,
+            "date_to": self.today_str,
+        })
+        self.assertEqual(response.context["dashboard"]["occupancy_rate"], 0.0)
+
+    def test_occupancy_rate_is_zero_when_no_rooms_exist(self):
+        Room.objects.all().delete()
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.context["dashboard"]["occupancy_rate"], 0.0)
+
+    def test_occupancy_rate_calculates_correctly_for_range(self):
+        room2 = create_room("Room 1.2", self.rt)
+        room3 = create_room("Room 1.3", self.rt)
+        room4 = create_room("Room 1.4", self.rt)
+        tomorrow = self.today + datetime.timedelta(days=1)
+        create_booking(self.room, self.customer, checkin=self.today, checkout=tomorrow)
+        create_booking(room2, self.customer, checkin=self.today, checkout=tomorrow)
+        create_booking(room3, self.customer, checkin=self.today, checkout=tomorrow)
+        response = self.client.get(reverse("dashboard"), {
+            "date_from": self.today_str,
+            "date_to": self.today_str,
+        })
+        # 3 confirmed overlapping / 4 rooms = 75.0%
+        self.assertEqual(response.context["dashboard"]["occupancy_rate"], 75.0)
+
+    def test_cancelled_bookings_are_excluded_from_occupancy(self):
+        tomorrow = self.today + datetime.timedelta(days=1)
+        create_booking(self.room, self.customer, state=Booking.DELETED,
+                       checkin=self.today, checkout=tomorrow)
+        response = self.client.get(reverse("dashboard"), {
+            "date_from": self.today_str,
+            "date_to": self.today_str,
+        })
+        self.assertEqual(response.context["dashboard"]["occupancy_rate"], 0.0)
+
+    def test_booking_outside_range_is_excluded(self):
+        last_week = self.today - datetime.timedelta(days=7)
+        last_week_end = self.today - datetime.timedelta(days=3)
+        create_booking(self.room, self.customer, checkin=last_week, checkout=last_week_end)
+        response = self.client.get(reverse("dashboard"), {
+            "date_from": self.today_str,
+            "date_to": self.today_str,
+        })
+        self.assertEqual(response.context["dashboard"]["occupancy_rate"], 0.0)
+
+    def test_occupancy_rate_is_in_dashboard_context(self):
+        response = self.client.get(reverse("dashboard"))
+        self.assertIn("occupancy_rate", response.context["dashboard"])

--- a/pms/views.py
+++ b/pms/views.py
@@ -179,47 +179,71 @@ class DashboardView(View):
         from datetime import date, time, datetime
         today = date.today()
 
-        # get bookings created today
-        today_min = datetime.combine(today, time.min)
-        today_max = datetime.combine(today, time.max)
-        today_range = (today_min, today_max)
+        try:
+            date_from = datetime.strptime(request.GET.get('date_from', ''), '%Y-%m-%d').date()
+        except ValueError:
+            date_from = today
+        try:
+            date_to = datetime.strptime(request.GET.get('date_to', ''), '%Y-%m-%d').date()
+        except ValueError:
+            date_to = today
+
+        if date_from > date_to:
+            date_from, date_to = date_to, date_from
+
+        range_min = datetime.combine(date_from, time.min)
+        range_max = datetime.combine(date_to, time.max)
+        created_range = (range_min, range_max)
+
         new_bookings = (Booking.objects
-                        .filter(created__range=today_range)
+                        .filter(created__range=created_range)
                         .values("id")
                         ).count()
 
         # get incoming guests
         incoming = (Booking.objects
-                    .filter(checkin=today)
+                    .filter(checkin__range=(date_from, date_to))
                     .exclude(state="DEL")
                     .values("id")
                     ).count()
 
         # get outcoming guests
         outcoming = (Booking.objects
-                     .filter(checkout=today)
+                     .filter(checkout__range=(date_from, date_to))
                      .exclude(state="DEL")
                      .values("id")
                      ).count()
 
         # get outcoming guests
         invoiced = (Booking.objects
-                    .filter(created__range=today_range)
+                    .filter(created__range=created_range)
                     .exclude(state="DEL")
                     .aggregate(Sum('total'))
                     )
 
-        # preparing context data
+        # a booking overlaps the range if: checkin <= date_to AND checkout > date_from
+        total_rooms = Room.objects.count()
+        confirmed_bookings = (Booking.objects
+                              .filter(
+                                  state=Booking.NEW,
+                                  checkin__lte=date_to,
+                                  checkout__gt=date_from,
+                              )
+                              .count())
+        occupancy_rate = round((confirmed_bookings / total_rooms) * 100, 2) if total_rooms > 0 else 0.0
+
         dashboard = {
             'new_bookings': new_bookings,
             'incoming_guests': incoming,
             'outcoming_guests': outcoming,
-            'invoiced': invoiced
-
+            'invoiced': invoiced,
+            'occupancy_rate': occupancy_rate,
         }
 
         context = {
-            'dashboard': dashboard
+            'dashboard': dashboard,
+            'date_from': date_from.strftime('%Y-%m-%d'),
+            'date_to': date_to.strftime('%Y-%m-%d'),
         }
         return render(request, "dashboard.html", context)
 


### PR DESCRIPTION
- add date_from / date_to query params to DashboardView (defaults to today)
- swap inverted date ranges automatically
- calculate occupancy rate: confirmed bookings overlapping range / total rooms
- guard against division by zero when no rooms exist
- simplify total invoiced template rendering using default filter
- add date range form to dashboard.html
- add % Ocupación widget following existing card style