### PR TITLE
Añadir formulario de edición de reservas y validación de fechas

### DIFF
--- a/pms/forms.py
+++ b/pms/forms.py
@@ -56,3 +56,34 @@ class BookingFormExcluded(ModelForm):
             'total': forms.HiddenInput(),
             'state': forms.HiddenInput(),
         }
+
+class BookingFormDates(forms.ModelForm):
+    class Meta:
+        model = Booking
+        fields = ['checkin', 'checkout']
+        widgets = {
+            'checkin': forms.DateInput(
+                attrs={
+                    'type': 'date', 
+                    'min': datetime.today().strftime('%Y-%m-%d'),
+                    'id': 'id_checkin'
+                }
+            ),
+            'checkout': forms.DateInput(
+                attrs={
+                    'type': 'date', 
+                    'max': datetime.today().replace(month=12, day=31).strftime('%Y-%m-%d'),
+                    'id': 'id_checkout'
+                }
+            )
+        }
+    
+    def clean(self):
+        cleaned_data = super().clean()
+        checkin = cleaned_data.get('checkin')
+        checkout = cleaned_data.get('checkout')
+        
+        if checkin and checkout and checkout <= checkin:
+            raise forms.ValidationError('La fecha de salida debe ser posterior a la fecha de entrada')
+        
+        return cleaned_data

--- a/pms/templates/home.html
+++ b/pms/templates/home.html
@@ -68,7 +68,7 @@
                     <a href="{% url 'edit_booking' pk=booking.id%} " >Editar datos de contacto</a>
                 </div>
                 <div class="col">
-
+                    <a href="{% url 'update_booking' pk=booking.id%} " >Editar datos de la reserva</a>
                 </div>
                 <div class="col">
 

--- a/pms/templates/update_booking.html
+++ b/pms/templates/update_booking.html
@@ -1,0 +1,79 @@
+{% extends "main.html"%}
+
+{% block content %}
+<h1>Editar fechas de reserva</h1>
+<div class="card card-body mb-3">
+    <div class="row">
+        <div class="col">
+            Reserva: {{booking.code}}
+            {% if booking.state == "DEL" %}
+            <span class="tag tag-red">Cancelada</span>
+            {% elif booking.state == "NEW" %}
+            <span class="tag tag-green">Confirmada</span>
+            {% endif %}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            <p>Reserva para {{booking.guest.first_name}} {{booking.guest.last_name}}</p>
+            <p>Habitación: {{booking.room.name}}</p>
+            <p>Fechas actuales: {{booking.checkin}} - {{booking.checkout}}</p>
+        </div>
+    </div>
+</div>
+<form action="" method="post">
+
+    {% csrf_token%}
+    {% if booking_form.non_field_errors %}
+        <div class="alert alert-danger">
+            {% for error in booking_form.non_field_errors %}
+                {{ error }}
+            {% endfor %}
+        </div>
+    {% endif %}
+    {% for field in booking_form %}
+    <div class="row">
+        {% if field.errors %}
+        <div class="col">
+            <div class="alert alert-danger">
+                {% for error in field.errors %}
+                    {{ error }}
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+        <div class="col-md-2">
+            {{field.label_tag}}
+        </div>
+        <div class="col">
+            {{field}}
+        </div>
+    </div>
+    {% endfor %}
+    <div class="row">
+        <div class="col"><span>Días: </span><span id="total-days"></span></div>
+    </div>
+    <div>
+        <a class="btn btn-outline-primary" href="{% url 'home' %}">Volver</a>
+        <button class="btn btn-primary" type="submit">Guardar datos</button>
+    </div>
+</form>
+<script>
+    
+    function onDateUpdate(){
+        const date1=new Date(document.querySelector("#id_checkin").value)
+        const date2=new Date(document.querySelector("#id_checkout").value)
+        console.log((date2.getTime() - date1.getTime())/(1000*3600*24));
+        document.querySelector("#total-days").innerHTML=(date2.getTime() - date1.getTime())/(1000*3600*24)
+
+    }
+    document.querySelector("#id_checkout").addEventListener("change",(e)=>{
+        onDateUpdate()
+    });
+    document.querySelector("#id_checkin").addEventListener("change",(e)=>{
+        onDateUpdate()
+    });
+    onDateUpdate();
+</script>
+
+{% endblock content %}

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/pms/tests/test_forms.py
+++ b/pms/tests/test_forms.py
@@ -1,0 +1,199 @@
+from django.test import TestCase
+from django import forms
+from datetime import date, datetime, timedelta
+from unittest.mock import patch
+from pms.forms import BookingFormDates
+from pms.models import Booking
+
+
+class BookingFormDatesTest(TestCase):
+    """Unit tests BookingFormDates"""
+    
+    def setUp(self):
+        """Initial setup for tests"""
+        self.today = date.today()
+        self.tomorrow = self.today + timedelta(days=1)
+        self.next_week = self.today + timedelta(days=7)
+    
+    def test_form_is_valid_with_valid_dates(self):
+        """Test that the form is valid with correct dates"""
+        form_data = {
+            'checkin': self.tomorrow.strftime('%Y-%m-%d'),
+            'checkout': self.next_week.strftime('%Y-%m-%d')
+        }
+        form = BookingFormDates(data=form_data)
+        self.assertTrue(form.is_valid())
+    
+    def test_form_invalid_when_checkout_equals_checkin(self):
+        """Test that the form is invalid when checkout equals checkin"""
+        form_data = {
+            'checkin': self.tomorrow.strftime('%Y-%m-%d'),
+            'checkout': self.tomorrow.strftime('%Y-%m-%d')
+        }
+        form = BookingFormDates(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('__all__', form.errors)
+        self.assertEqual(
+            form.non_field_errors()[0],
+            'La fecha de salida debe ser posterior a la fecha de entrada'
+        )
+    
+    def test_form_invalid_when_checkout_earlier_than_checkin(self):
+        """Test that the form is invalid when checkout is earlier than checkin"""
+        form_data = {
+            'checkin': self.tomorrow.strftime('%Y-%m-%d'),
+            'checkout': self.today.strftime('%Y-%m-%d')
+        }
+        form = BookingFormDates(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('__all__', form.errors)
+        self.assertEqual(
+            form.non_field_errors()[0],
+            'La fecha de salida debe ser posterior a la fecha de entrada'
+        )
+    
+    def test_form_clean_method_handles_missing_checkin(self):
+        """Test that clean() handles missing checkin correctly"""
+        form_data = {
+            'checkout': self.tomorrow.strftime('%Y-%m-%d')
+        }
+        form = BookingFormDates(data=form_data)
+        # The form will be invalid due to missing fields, but it should not raise an exception
+        self.assertFalse(form.is_valid())
+        self.assertIn('checkin', form.errors)
+    
+    def test_form_clean_method_handles_missing_checkout(self):
+        """Test that clean() handles missing checkout correctly"""
+        form_data = {
+            'checkin': self.tomorrow.strftime('%Y-%m-%d')
+        }
+        form = BookingFormDates(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('checkout', form.errors)
+    
+    def test_form_clean_method_handles_none_dates(self):
+        """Test that clean() handles None dates correctly"""
+        form_data = {
+            'checkin': None,
+            'checkout': None
+        }
+        form = BookingFormDates(data=form_data)
+        self.assertFalse(form.is_valid())
+    
+    def test_form_widget_attributes(self):
+        """Test that the widgets have the correct attributes"""
+        form = BookingFormDates()
+        
+        # Verify checkin widget
+        checkin_widget = form.fields['checkin'].widget
+        # The 'type' attribute may not exist, we check for 'min' and 'id'
+        self.assertEqual(checkin_widget.attrs.get('id'), 'id_checkin')
+        self.assertIn('min', checkin_widget.attrs)
+        
+        # Verify checkout widget
+        checkout_widget = form.fields['checkout'].widget
+        self.assertEqual(checkout_widget.attrs.get('id'), 'id_checkout')
+        self.assertIn('max', checkout_widget.attrs)
+    
+    def test_form_widget_has_correct_attrs(self):
+        """Test that the widgets have the correct attribute configuration"""
+        form = BookingFormDates()
+        
+        # Verify that the widgets are of the correct type
+        self.assertIsInstance(form.fields['checkin'].widget, forms.DateInput)
+        self.assertIsInstance(form.fields['checkout'].widget, forms.DateInput)
+        
+        # Verify specific attributes
+        self.assertEqual(form.fields['checkin'].widget.attrs.get('id'), 'id_checkin')
+        self.assertEqual(form.fields['checkout'].widget.attrs.get('id'), 'id_checkout')
+    
+    def test_checkin_min_date_is_today(self):
+        """Test that the min attribute of checkin is today's date"""
+        # No need to mock, we use the real date
+        form = BookingFormDates()
+        today_str = date.today().strftime('%Y-%m-%d')
+        self.assertEqual(form.fields['checkin'].widget.attrs.get('min'), today_str)
+    
+    def test_checkout_max_date_is_dec_31_current_year(self):
+        """Test that the max attribute of checkout is December 31 of the current year"""
+        form = BookingFormDates()
+        current_year = date.today().year
+        expected_max = date(current_year, 12, 31).strftime('%Y-%m-%d')
+        self.assertEqual(form.fields['checkout'].widget.attrs.get('max'), expected_max)
+    
+    def test_form_accepts_valid_date_range(self):
+        """Test that the form accepts a valid date range"""
+        valid_ranges = [
+            (self.today + timedelta(days=1), self.today + timedelta(days=2)),
+            (self.today + timedelta(days=1), self.today + timedelta(days=30)),
+            (self.today + timedelta(days=5), self.today + timedelta(days=10)),
+        ]
+        
+        for checkin, checkout in valid_ranges:
+            form_data = {
+                'checkin': checkin.strftime('%Y-%m-%d'),
+                'checkout': checkout.strftime('%Y-%m-%d')
+            }
+            form = BookingFormDates(data=form_data)
+            self.assertTrue(form.is_valid(), f"Failed for range {checkin} to {checkout}")
+    
+    def test_form_rejects_invalid_date_range(self):
+        """Test that the form rejects invalid date ranges"""
+        invalid_ranges = [
+            (self.today + timedelta(days=1), self.today + timedelta(days=1)),  # iguales
+            (self.today + timedelta(days=2), self.today + timedelta(days=1)),  # checkout menor
+            (self.today, self.today),  # iguales incluyendo hoy
+            (self.today + timedelta(days=5), self.today + timedelta(days=3)),  # checkout menor
+        ]
+        
+        for checkin, checkout in invalid_ranges:
+            form_data = {
+                'checkin': checkin.strftime('%Y-%m-%d'),
+                'checkout': checkout.strftime('%Y-%m-%d')
+            }
+            form = BookingFormDates(data=form_data)
+            self.assertFalse(form.is_valid(), f"Should be invalid for range {checkin} to {checkout}")
+            self.assertIn('__all__', form.errors)
+    
+    def test_form_meta_fields(self):
+        """Test that the Meta has the correct fields"""
+        form = BookingFormDates()
+        self.assertEqual(list(form.Meta.fields), ['checkin', 'checkout'])
+        self.assertEqual(form.Meta.model, Booking)
+
+
+class BookingFormDatesEdgeCasesTest(TestCase):
+    """Tests for edge cases of the BookingFormDates form"""
+    
+    def test_form_with_dates_in_same_year(self):
+        """Test with dates within the same year"""
+        today = date.today()
+        form_data = {
+            'checkin': (today + timedelta(days=1)).strftime('%Y-%m-%d'),
+            'checkout': (today + timedelta(days=10)).strftime('%Y-%m-%d')
+        }
+        form = BookingFormDates(data=form_data)
+        self.assertTrue(form.is_valid())
+    
+    def test_form_requires_future_checkin(self):
+        """Test that the checkin must be in the future (due to the min attribute of the widget)"""
+        form = BookingFormDates()
+        min_date = form.fields['checkin'].widget.attrs.get('min')
+        self.assertIsNotNone(min_date)
+        
+        # Verify that min_date is equal to or after today
+        min_date_obj = datetime.strptime(min_date, '%Y-%m-%d').date()
+        self.assertGreaterEqual(min_date_obj, date.today())
+    
+    def test_form_limits_checkout_to_current_year(self):
+        """Test that the checkout is limited to the current year"""
+        form = BookingFormDates()
+        max_date = form.fields['checkout'].widget.attrs.get('max')
+        self.assertIsNotNone(max_date)
+        
+        # Verify that max_date is December 31 of the current year
+        max_date_obj = datetime.strptime(max_date, '%Y-%m-%d').date()
+        current_year = date.today().year
+        self.assertEqual(max_date_obj.year, current_year)
+        self.assertEqual(max_date_obj.month, 12)
+        self.assertEqual(max_date_obj.day, 31)

--- a/pms/tests/test_views.py
+++ b/pms/tests/test_views.py
@@ -1,0 +1,528 @@
+from django.test import TestCase, RequestFactory, override_settings
+from django.urls import reverse
+from datetime import date, timedelta
+from pms.models import Booking, Room, Room_type, Customer
+from pms.views import UpdateBookingView
+
+
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class UpdateBookingViewTest(TestCase):
+    """Unit tests for UpdateBookingView"""
+    
+    def setUp(self):
+        """Set up test data"""
+        self.factory = RequestFactory()
+        self.today = date.today()
+        self.tomorrow = self.today + timedelta(days=1)
+        self.day_after_tomorrow = self.today + timedelta(days=2)
+        self.next_week = self.today + timedelta(days=7)
+        
+    
+        self.room_type = Room_type.objects.create(
+            name="Standard Room",
+            price=100.00,
+            max_guests=2
+        )
+        
+    
+        self.room = Room.objects.create(
+            room_type=self.room_type,
+            name="Test Room 101",
+            description="A comfortable test room"
+        )
+        
+    
+        self.customer = Customer.objects.create(
+            name="Test Customer",
+            email="test@example.com",
+            phone="+1234567890"
+        )
+        
+    
+        self.booking = Booking.objects.create(
+            room=self.room,
+            checkin=self.tomorrow,
+            checkout=self.next_week,
+            state=Booking.NEW,
+            guests=2,
+            customer=self.customer,
+            total=700.00,
+            code="TEST001"
+        )
+        
+        self.url = reverse('update_booking', kwargs={'pk': self.booking.id})
+    
+    def test_get_request_renders_update_form(self):
+        """Test that GET request renders the form with booking data"""
+        response = self.client.get(self.url)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "update_booking.html")
+        self.assertIn('booking_form', response.context)
+        self.assertIn('booking', response.context)
+        self.assertEqual(response.context['booking'], self.booking)
+        
+    
+        form = response.context['booking_form']
+        self.assertEqual(form.prefix, "booking")
+        self.assertEqual(form.instance, self.booking)
+    
+    def test_get_request_with_invalid_pk_returns_404(self):
+        """Test that GET with invalid pk returns 404"""
+        invalid_url = reverse('update_booking', kwargs={'pk': 99999})
+        response = self.client.get(invalid_url)
+        self.assertEqual(response.status_code, 404)
+    
+    def test_post_valid_update_without_conflicts_redirects(self):
+        """Test that POST with valid data without conflicts redirects to home"""
+        post_data = {
+            'booking-checkin': self.day_after_tomorrow.strftime('%Y-%m-%d'),
+            'booking-checkout': (self.day_after_tomorrow + timedelta(days=3)).strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+    
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/")
+        
+    
+        self.booking.refresh_from_db()
+        self.assertEqual(self.booking.checkin, self.day_after_tomorrow)
+        self.assertEqual(self.booking.checkout, self.day_after_tomorrow + timedelta(days=3))
+    
+    def test_post_valid_update_updates_booking(self):
+        """Test that POST correctly updates the booking"""
+        new_checkin = self.tomorrow + timedelta(days=1)
+        new_checkout = self.tomorrow + timedelta(days=5)
+        
+        post_data = {
+            'booking-checkin': new_checkin.strftime('%Y-%m-%d'),
+            'booking-checkout': new_checkout.strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+        self.booking.refresh_from_db()
+        self.assertEqual(self.booking.checkin, new_checkin)
+        self.assertEqual(self.booking.checkout, new_checkout)
+    
+    def test_post_with_conflicting_booking_shows_error(self):
+        """Test that POST with conflicting dates shows error"""
+    
+        conflicting_booking = Booking.objects.create(
+            room=self.room,
+            checkin=self.tomorrow + timedelta(days=2),
+            checkout=self.tomorrow + timedelta(days=4),
+            state=Booking.NEW,
+            guests=2,
+            customer=self.customer,
+            total=200.00,
+            code="CONF001"
+        )
+        
+    
+        post_data = {
+            'booking-checkin': (self.tomorrow + timedelta(days=1)).strftime('%Y-%m-%d'),
+            'booking-checkout': (self.tomorrow + timedelta(days=3)).strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+    
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "update_booking.html")
+        
+    
+        form = response.context['booking_form']
+        self.assertFalse(form.is_valid())
+        self.assertIn('No hay disponibilidad para las fechas seleccionadas', str(form.non_field_errors()))
+        
+    
+        self.booking.refresh_from_db()
+        self.assertNotEqual(self.booking.checkin, self.tomorrow + timedelta(days=1))
+    
+    def test_post_with_conflicting_booking_excludes_current_booking(self):
+        """Test that conflict check excludes the current booking"""
+    
+        other_booking = Booking.objects.create(
+            room=self.room,
+            checkin=self.tomorrow + timedelta(days=3),
+            checkout=self.tomorrow + timedelta(days=5),
+            state=Booking.NEW,
+            guests=2,
+            customer=self.customer,
+            total=200.00,
+            code="OTHER001"
+        )
+        
+    
+        post_data = {
+            'booking-checkin': (self.tomorrow + timedelta(days=1)).strftime('%Y-%m-%d'),
+            'booking-checkout': (self.tomorrow + timedelta(days=2)).strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+    
+        self.assertEqual(response.status_code, 302)
+        
+    
+        self.booking.refresh_from_db()
+        self.assertEqual(self.booking.checkin, self.tomorrow + timedelta(days=1))
+        self.assertEqual(self.booking.checkout, self.tomorrow + timedelta(days=2))
+    
+    def test_post_with_invalid_form_data_rerenders_form(self):
+        """Test that POST with invalid data re-renders form with errors"""
+        post_data = {
+            'booking-checkin': 'invalid-date',
+            'booking-checkout': 'invalid-date'
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "update_booking.html")
+        
+    
+        form = response.context['booking_form']
+        self.assertFalse(form.is_valid())
+        self.assertIn('checkin', form.errors)
+    
+    def test_post_with_checkout_less_than_checkin_shows_error(self):
+        """Test that POST with checkout earlier than checkin shows validation error"""
+        post_data = {
+            'booking-checkin': self.next_week.strftime('%Y-%m-%d'),
+            'booking-checkout': self.tomorrow.strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+        self.assertEqual(response.status_code, 200)
+        form = response.context['booking_form']
+        self.assertFalse(form.is_valid())
+        self.assertIn('La fecha de salida debe ser posterior a la fecha de entrada', str(form.non_field_errors()))
+    
+    def test_post_with_same_checkin_checkout_shows_error(self):
+        """Test that POST with checkin equal to checkout shows error"""
+        post_data = {
+            'booking-checkin': self.tomorrow.strftime('%Y-%m-%d'),
+            'booking-checkout': self.tomorrow.strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+        self.assertEqual(response.status_code, 200)
+        form = response.context['booking_form']
+        self.assertFalse(form.is_valid())
+        self.assertIn('La fecha de salida debe ser posterior a la fecha de entrada', str(form.non_field_errors()))
+    
+    def test_post_with_missing_dates_shows_error(self):
+        """Test that POST with missing dates shows error"""
+        post_data = {
+            'booking-checkin': '',
+            'booking-checkout': ''
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+        self.assertEqual(response.status_code, 200)
+        form = response.context['booking_form']
+        self.assertFalse(form.is_valid())
+        self.assertIn('checkin', form.errors)
+        self.assertIn('checkout', form.errors)
+    
+    def test_post_updates_only_dates_not_other_fields(self):
+        """Test that POST only updates dates, not other fields"""
+        original_guests = self.booking.guests
+        original_customer = self.booking.customer
+        original_room = self.booking.room
+        original_total = self.booking.total
+        original_code = self.booking.code
+        
+        post_data = {
+            'booking-checkin': self.day_after_tomorrow.strftime('%Y-%m-%d'),
+            'booking-checkout': (self.day_after_tomorrow + timedelta(days=3)).strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+        self.booking.refresh_from_db()
+        self.assertEqual(self.booking.guests, original_guests)
+        self.assertEqual(self.booking.customer, original_customer)
+        self.assertEqual(self.booking.room, original_room)
+        self.assertEqual(self.booking.total, original_total)
+        self.assertEqual(self.booking.code, original_code)
+    
+    def test_post_with_different_room_conflict(self):
+        """Test conflicts with bookings in different rooms"""
+    
+        other_room = Room.objects.create(
+            room_type=self.room_type,
+            name="Test Room 102",
+            description="Another test room"
+        )
+        
+    
+        conflicting_booking = Booking.objects.create(
+            room=other_room,
+            checkin=self.tomorrow + timedelta(days=2),
+            checkout=self.tomorrow + timedelta(days=4),
+            state=Booking.NEW,
+            guests=2,
+            customer=self.customer,
+            total=200.00,
+            code="CONF002"
+        )
+        
+    
+        post_data = {
+            'booking-checkin': (self.tomorrow + timedelta(days=1)).strftime('%Y-%m-%d'),
+            'booking-checkout': (self.tomorrow + timedelta(days=3)).strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+    
+        self.assertEqual(response.status_code, 302)
+        
+        self.booking.refresh_from_db()
+        self.assertEqual(self.booking.checkin, self.tomorrow + timedelta(days=1))
+    
+    def test_post_with_conflicting_state_not_new(self):
+        """Test that only bookings with state 'NEW' are considered conflicts"""
+    
+        non_conflicting_booking = Booking.objects.create(
+            room=self.room,
+            checkin=self.tomorrow + timedelta(days=2),
+            checkout=self.tomorrow + timedelta(days=4),
+            state=Booking.DELETED, 
+            guests=2,
+            customer=self.customer,
+            total=200.00,
+            code="CANCEL001"
+        )
+        
+    
+        post_data = {
+            'booking-checkin': (self.tomorrow + timedelta(days=1)).strftime('%Y-%m-%d'),
+            'booking-checkout': (self.tomorrow + timedelta(days=3)).strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+    
+        self.assertEqual(response.status_code, 302)
+        
+        self.booking.refresh_from_db()
+        self.assertEqual(self.booking.checkin, self.tomorrow + timedelta(days=1))
+
+
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class UpdateBookingViewIntegrationTest(TestCase):
+    """Integration tests for UpdateBookingView with multiple bookings"""
+    
+    def setUp(self):
+        """Set up test data with multiple bookings"""
+        self.today = date.today()
+        self.tomorrow = self.today + timedelta(days=1)
+        
+    
+        self.room_type = Room_type.objects.create(
+            name="Suite",
+            price=200.00,
+            max_guests=4
+        )
+        
+    
+        self.room = Room.objects.create(
+            room_type=self.room_type,
+            name="Suite Test",
+            description="Luxury suite"
+        )
+        
+    
+        self.customer = Customer.objects.create(
+            name="Integration Test Customer",
+            email="integration@example.com",
+            phone="+9876543210"
+        )
+        
+        self.booking1 = Booking.objects.create(
+            room=self.room,
+            checkin=self.tomorrow,
+            checkout=self.tomorrow + timedelta(days=3),
+            state=Booking.NEW,
+            guests=2,
+            customer=self.customer,
+            total=600.00,
+            code="INT001"
+        )
+        
+        self.booking2 = Booking.objects.create(
+            room=self.room,
+            checkin=self.tomorrow + timedelta(days=4),
+            checkout=self.tomorrow + timedelta(days=6),
+            state=Booking.NEW,
+            guests=2,
+            customer=self.customer,
+            total=400.00,
+            code="INT002"
+        )
+        
+        self.url = reverse('update_booking', kwargs={'pk': self.booking1.id})
+    
+    def test_update_between_existing_bookings_success(self):
+        """Test updating between two existing bookings succeeds"""
+    
+        post_data = {
+            'booking-checkin': (self.tomorrow + timedelta(days=3)).strftime('%Y-%m-%d'),
+            'booking-checkout': (self.tomorrow + timedelta(days=4)).strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+        self.assertEqual(response.status_code, 302)
+        
+        self.booking1.refresh_from_db()
+        self.assertEqual(self.booking1.checkout, self.tomorrow + timedelta(days=4))
+    
+    def test_update_overlapping_existing_booking_fails(self):
+        """Test that update overlapping with existing booking fails"""
+        post_data = {
+            'booking-checkin': (self.tomorrow + timedelta(days=2)).strftime('%Y-%m-%d'),
+            'booking-checkout': (self.tomorrow + timedelta(days=5)).strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+        self.assertEqual(response.status_code, 200)
+        form = response.context['booking_form']
+        self.assertIn('No hay disponibilidad para las fechas seleccionadas', str(form.non_field_errors()))
+    
+    def test_update_exactly_adjacent_to_existing_booking_succeeds(self):
+        """Test that update exactly adjacent to existing booking succeeds (no overlap)"""
+        post_data = {
+            'booking-checkin': (self.tomorrow + timedelta(days=3)).strftime('%Y-%m-%d'),
+            'booking-checkout': (self.tomorrow + timedelta(days=4)).strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        
+        self.assertEqual(response.status_code, 302)
+        
+    
+        self.booking1.refresh_from_db()
+        self.booking2.refresh_from_db()
+        self.assertLessEqual(self.booking1.checkout, self.booking2.checkin)
+
+
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class UpdateBookingViewEdgeCasesTest(TestCase):
+    """Edge cases tests for UpdateBookingView"""
+    
+    def setUp(self):
+        """Set up test data for edge cases"""
+        self.today = date.today()
+        self.tomorrow = self.today + timedelta(days=1)
+        
+    
+        self.room_type = Room_type.objects.create(
+            name="Economy",
+            price=50.00,
+            max_guests=2
+        )
+        
+    
+        self.room = Room.objects.create(
+            room_type=self.room_type,
+            name="Economy Room",
+            description="Budget room"
+        )
+        
+    
+        self.customer = Customer.objects.create(
+            name="Edge Case Customer",
+            email="edge@example.com",
+            phone="+1111111111"
+        )
+        
+        self.booking = Booking.objects.create(
+            room=self.room,
+            checkin=self.tomorrow,
+            checkout=self.tomorrow + timedelta(days=3),
+            state=Booking.NEW,
+            guests=1,
+            customer=self.customer,
+            total=150.00,
+            code="EDGE001"
+        )
+        
+        self.url = reverse('update_booking', kwargs={'pk': self.booking.id})
+    
+    def test_update_with_boundary_dates(self):
+        """Test updating with boundary dates (minimum and maximum allowed)"""
+    
+        min_checkin = self.tomorrow
+        min_checkout = self.tomorrow + timedelta(days=1)
+        
+        post_data = {
+            'booking-checkin': min_checkin.strftime('%Y-%m-%d'),
+            'booking-checkout': min_checkout.strftime('%Y-%m-%d')
+        }
+        
+        response = self.client.post(self.url, post_data)
+        self.assertEqual(response.status_code, 302)
+        
+        self.booking.refresh_from_db()
+        self.assertEqual(self.booking.checkin, min_checkin)
+        self.assertEqual(self.booking.checkout, min_checkout)
+    
+    def test_update_with_maximum_range_in_same_year(self):
+        """Test updating with maximum range within same year"""
+    
+        end_of_year = date(self.today.year, 12, 31)
+        
+        if end_of_year > self.tomorrow:
+            post_data = {
+                'booking-checkin': self.tomorrow.strftime('%Y-%m-%d'),
+                'booking-checkout': end_of_year.strftime('%Y-%m-%d')
+            }
+            
+            response = self.client.post(self.url, post_data)
+            self.assertEqual(response.status_code, 302)
+            
+            self.booking.refresh_from_db()
+            self.assertEqual(self.booking.checkout, end_of_year)
+    
+    def test_update_same_booking_multiple_times(self):
+        """Test updating the same booking multiple times"""
+    
+        first_checkin = self.tomorrow + timedelta(days=1)
+        first_checkout = self.tomorrow + timedelta(days=2)
+        
+        post_data1 = {
+            'booking-checkin': first_checkin.strftime('%Y-%m-%d'),
+            'booking-checkout': first_checkout.strftime('%Y-%m-%d')
+        }
+        
+        response1 = self.client.post(self.url, post_data1)
+        self.assertEqual(response1.status_code, 302)
+        
+    
+        second_checkin = first_checkin + timedelta(days=1)
+        second_checkout = first_checkout + timedelta(days=2)
+        
+        post_data2 = {
+            'booking-checkin': second_checkin.strftime('%Y-%m-%d'),
+            'booking-checkout': second_checkout.strftime('%Y-%m-%d')
+        }
+        
+        response2 = self.client.post(self.url, post_data2)
+        self.assertEqual(response2.status_code, 302)
+        
+        self.booking.refresh_from_db()
+        self.assertEqual(self.booking.checkin, second_checkin)
+        self.assertEqual(self.booking.checkout, second_checkout)
+    
+    

--- a/pms/urls.py
+++ b/pms/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("booking/<str:pk>/", views.BookingView.as_view(), name="booking"),
     path("booking/<str:pk>/edit", views.EditBookingView.as_view(), name="edit_booking"),
     path("booking/<str:pk>/delete", views.DeleteBookingView.as_view(), name="delete_booking"),
+    path("booking/<str:pk>/update", views.UpdateBookingView.as_view(), name="update_booking"),
     path("rooms/", views.RoomsView.as_view(), name="rooms"),
     path("room/<str:pk>/", views.RoomDetailsView.as_view(), name="room_details"),
     path("dashboard/", views.DashboardView.as_view(), name="dashboard")

--- a/pms/views.py
+++ b/pms/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import render, redirect
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
+from django.shortcuts import get_object_or_404
 
 from .form_dates import Ymd
 from .forms import *
@@ -244,3 +245,51 @@ class RoomsView(View):
             'rooms': rooms
         }
         return render(request, "rooms.html", context)
+    
+class UpdateBookingView(View):
+    # renders the booking edition form
+    def get(self, request, pk):
+        booking = get_object_or_404(Booking, id=pk)
+        booking_form = BookingFormDates(prefix="booking", instance=booking)
+        
+        context = {
+            'booking_form': booking_form,
+            'booking': booking
+        }
+        return render(request, "update_booking.html", context)
+
+    # updates the booking form
+    @method_decorator(ensure_csrf_cookie)
+    def post(self, request, pk):
+        booking = get_object_or_404(Booking, id=pk)
+        booking_form = BookingFormDates(request.POST, prefix="booking", instance=booking)
+        
+        if booking_form.is_valid():
+            new_checkin = booking_form.cleaned_data['checkin']
+            new_checkout = booking_form.cleaned_data['checkout']
+            conflicting_bookings = Booking.objects.filter(
+                room=booking.room,
+                checkin__lt=new_checkout,
+                checkout__gt=new_checkin,
+                state="NEW"
+            ).exclude(id=booking.id)
+            
+            if conflicting_bookings.exists():
+                booking_form.add_error(None, 'No hay disponibilidad para las fechas seleccionadas')
+                context = {
+                    'booking_form': booking_form,
+                    'booking': booking
+                }
+                return render(request, "update_booking.html", context)
+            
+            booking.checkin = new_checkin
+            booking.checkout = new_checkout
+            booking.save()
+            return redirect("/")
+        
+        # If form is invalid, re-render with errors
+        context = {
+            'booking_form': booking_form,
+            'booking': booking
+        }
+        return render(request, "update_booking.html", context)


### PR DESCRIPTION
# Añadir formulario de edición de reservas y validación de fechas

## Resumen

Se incorpora una funcionalidad que permite la edición de las fechas de reservas existentes por parte del usuario desde la interfaz web. Se implementa validación de fechas tanto a nivel de formulario como de lógica de backend para evitar solapamientos de reservas y asegurar la integridad de los datos. Además, se agregan pruebas unitarias exhaustivas.

---

## Cambios realizados

- **Nuevo formulario `BookingFormDates`:**
  - Agregado en `pms/forms.py`, permite editar las fechas de una reserva (`checkin`, `checkout`) con validaciones personalizadas en el método `clean()`.
  - Limita las fechas válidas con los atributos `min` y `max` en los widgets mediante atributos tipo HTML.

- **Vista y plantilla de edición:**
  - Nuevo template `pms/templates/update_booking.html` para la UI de edición de fechas, mostrando siempre los mensajes de error y el estado de la reserva.
  - Se adapta el botón en `home.html` para dirigir correctamente a la edición de fechas.
  - Agregado JS ligero para mostrar los días de estancia según la fecha seleccionada.

- **Lógica en backend:**
  - Nueva vista `UpdateBookingView` en `pms/views.py` para GET (renderiza formulario) y POST (procesa actualización).
  - Previene solapamientos de reservas sobre la misma habitación validando en la base de datos.
  - Se muestra un error específico al usuario si no hay disponibilidad para las fechas elegidas.

- **Rutas Django:**
  - Se incorpora `booking/<str:pk>/update` en `pms/urls.py` para acceder y procesar la edición de reservas.

- **Pruebas unitarias:**
  - Nuevo archivo `pms/tests/test_forms.py` con pruebas exhaustivas sobre el formulario de edición de fechas: casos válidos, inválidos, verificación de atributos HTML y validación de rangos.

---

## Detalles Técnicos

- El formulario sólo permite editar fechas futuras y restringe el checkout hasta fin de año actual.
- La validación impide que la fecha de salida sea igual o anterior a la de entrada.
- El backend realiza verificación adicional de solapamiento con reservas existentes de tipo "NEW".
- Se eliminó el antiguo archivo `tests.py` y se reorganizó bajo una estructura modular en `tests/`.

---

## Pruebas realizadas

- Pruebas unitarias sobre el formulario, cubriendo fechas límites, rangos válidos e inválidos, y vigilancia sobre los atributos de widgets.
- Pruebas manuales de validación de fechas y restricciones de disponibilidad sobre la interfaz.
